### PR TITLE
Added a checkbox to make the Quest repeatable or not

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/ConversationController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/ConversationController.java
@@ -18,6 +18,7 @@ import com.gpl.rpg.AndorsTrail.model.map.LayeredTileMap;
 import com.gpl.rpg.AndorsTrail.model.map.MapObject;
 import com.gpl.rpg.AndorsTrail.model.map.MonsterSpawnArea;
 import com.gpl.rpg.AndorsTrail.model.map.PredefinedMap;
+import com.gpl.rpg.AndorsTrail.model.quest.Quest;
 import com.gpl.rpg.AndorsTrail.model.quest.QuestLogEntry;
 import com.gpl.rpg.AndorsTrail.model.quest.QuestProgress;
 import com.gpl.rpg.AndorsTrail.model.script.Requirement;
@@ -155,7 +156,13 @@ public final class ConversationController {
 
 	private void addQuestProgressReward(Player player, String questID, int questProgress, ScriptEffectResult result) {
 		QuestProgress progress = new QuestProgress(questID, questProgress);
-		boolean added = player.addQuestProgress(progress);
+        Quest currentQuest = world.quests.getQuest(questID);
+
+        boolean added = player.addQuestProgress(progress);
+        if(currentQuest.repeatable) {
+            player.resetQuestIfFinished(currentQuest, questProgress);
+        }
+
 		if (!added) return; // Only apply exp reward if the quest stage was reached just now (and not re-reached)
 
 		QuestLogEntry stage = world.quests.getQuestLogEntry(progress);

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/actor/Player.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/actor/Player.java
@@ -11,6 +11,8 @@ import com.gpl.rpg.AndorsTrail.model.ability.SkillCollection;
 import com.gpl.rpg.AndorsTrail.model.item.DropListCollection;
 import com.gpl.rpg.AndorsTrail.model.item.Inventory;
 import com.gpl.rpg.AndorsTrail.model.item.Loot;
+import com.gpl.rpg.AndorsTrail.model.quest.Quest;
+import com.gpl.rpg.AndorsTrail.model.quest.QuestLogEntry;
 import com.gpl.rpg.AndorsTrail.model.quest.QuestProgress;
 import com.gpl.rpg.AndorsTrail.resource.tiles.TileManager;
 import com.gpl.rpg.AndorsTrail.savegames.LegacySavegameFormatReaderForPlayer;
@@ -153,6 +155,13 @@ public final class Player extends Actor {
 		questProgress.get(progress.questID).add(progress.progress);
 		return true; //Progress was added.
 	}
+
+    public void resetQuestIfFinished(Quest quest, int progress){
+        QuestLogEntry logEntry =  quest.getQuestLogEntry(progress);
+        if(logEntry.finishesQuest){
+            questProgress.remove(quest.questID);
+        }
+    }
 
 	public void recalculateLevelExperience() {
 		int experienceRequiredToReachThisLevel = getRequiredExperience(level);

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/quest/Quest.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/quest/Quest.java
@@ -10,6 +10,7 @@ public final class Quest implements Comparable<Quest> {
 	public final QuestLogEntry[] stages; //Must be sorted in ascending stage order
 	public final boolean showInLog;
 	public final int sortOrder;
+    public final boolean repeatable;
 
 	public Quest(
 			String questID
@@ -17,12 +18,14 @@ public final class Quest implements Comparable<Quest> {
 			, QuestLogEntry[] stages
 			, boolean showInLog
 			, int sortOrder
+            , boolean repeatable
 	) {
 		this.questID = questID;
 		this.name = name;
 		this.stages = stages;
 		this.showInLog = showInLog;
 		this.sortOrder = sortOrder;
+        this.repeatable = repeatable;
 	}
 
 	public QuestLogEntry getQuestLogEntry(final int progress) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/resource/parsers/QuestParser.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/resource/parsers/QuestParser.java
@@ -54,6 +54,7 @@ public final class QuestParser extends JsonCollectionParserFor<Quest> {
 				, stages
 				, o.optInt(JsonFieldNames.Quest.showInLog, 0) > 0
 				, sortOrder
+                , o.optInt(JsonFieldNames.Quest.repeatable, 0) > 0
 		));
 	}
 }

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/resource/parsers/json/JsonFieldNames.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/resource/parsers/json/JsonFieldNames.java
@@ -91,6 +91,7 @@ public final class JsonFieldNames {
 		public static final String name = "name";
 		public static final String showInLog = "showInLog";
 		public static final String stages = "stages";
+        public static final String repeatable = "repeatable";
 	}
 
 	public static final class QuestLogEntry {

--- a/AndorsTrailEdit/js/legacyimport.js
+++ b/AndorsTrailEdit/js/legacyimport.js
@@ -7,7 +7,7 @@ var ATEditor = (function(ATEditor, model, FieldList, _) {
 				+ "hasAbilityEffect|boostMaxHP|boostMaxAP|moveCostPenalty|attackCost|attackChance|criticalChance|criticalMultiplier|attackDamage_Min|attackDamage_Max|blockChance|damageResistance|"
 				+ "];"
 			);
-		model.quests.legacyFieldList = new FieldList("[id|name|showInLog|stages[progress|logText|rewardExperience|finishesQuest|]|];");
+		model.quests.legacyFieldList = new FieldList("[id|name|showInLog|stages[progress|logText|rewardExperience|removeQuestProgress|finishesQuest|]|];");
 		model.items.legacyFieldList = new FieldList("[id|iconID|name|category|displaytype|hasManualPrice|baseMarketCost|"
 				+ "hasEquipEffect|equip_boostMaxHP|equip_boostMaxAP|equip_moveCostPenalty|equip_attackCost|equip_attackChance|equip_criticalChance|equip_criticalMultiplier|equip_attackDamage_Min|equip_attackDamage_Max|equip_blockChance|equip_damageResistance|equip_conditions[condition|magnitude|]|"
 				+ "hasUseEffect|use_boostHP_Min|use_boostHP_Max|use_boostAP_Min|use_boostAP_Max|use_conditionsSource[condition|magnitude|duration|chance|]|"
@@ -94,7 +94,7 @@ var ATEditor = (function(ATEditor, model, FieldList, _) {
 	
 	
 	function convertQuest(obj) {
-		// [id|name|showInLog|stages[progress|logText|rewardExperience|finishesQuest|]|];
+		// [id|name|showInLog|stages[progress|logText|rewardExperience|removeQuestProgress|finishesQuest|]|];
 		return obj;
 	}
 	

--- a/AndorsTrailEdit/partials/edit_quest.html
+++ b/AndorsTrailEdit/partials/edit_quest.html
@@ -1,4 +1,4 @@
-<h3>Quest</h3>
+c<h3>Quest</h3>
 <fieldset>
 	<legend>General</legend>
 	<div class="fieldWithLabel">
@@ -22,6 +22,7 @@
 				<th><span class="hint  hint--top" data-hint="This number will not be displayed to the player. Must be some unique number for this quest though. Prefer values from 10-100.">Progress</span></th>
 				<th>Logtext</th>
 				<th><span class="hint  hint--top" data-hint="Reaching this quest stage gives this much experience">Experience</span></th>
+				<th><span class="hint  hint--top" data-hint="Finishing this stage will get you back to a specified progress">Remove quest progress</span></th>
 				<th>Finishes quest</th>
 				<th></th>
 			</tr></thead>
@@ -30,6 +31,7 @@
 					<td><input type="text" size="3" ng-model="stage.progress" class="at-input-stat"/></td>
 					<td><textarea rows="2" cols="40" ng-model="stage.logText"></textarea></td>
 					<td><input type="text" size="7" ng-model="stage.rewardExperience" class="at-input-stat"/></td>
+					<td><input type="text" size="7" ng-model="stage.removeQuestProgress" class="at-input-stat"/></td>
 					<td><input type="checkbox" ng-model="stage.finishesQuest" ng-true-value="1" ng-false-value="0" /></td>
 					<td><a ng-click="removeQuestStage(stage)" class="btn btn-mini" title="Remove row"><i class="icon-trash"></i></a></td>
 				</tr>


### PR DESCRIPTION
Added a checkbox to make the Quest repeatable or not.
When a quest is not repeatable, the exported Json File is not impacted.
When we want to import a Json File, if the repeatable line is absent, the quest will not be repeatable.

Here an example of what it'll look like :  
![repeatablequestedit](https://cloud.githubusercontent.com/assets/10435273/6212786/35f1a90e-b5e9-11e4-9f5a-488d15c05f66.png)
