### PR TITLE
Issue40 item compare

### DIFF
--- a/AndorsTrail/res/layout/iteminfo.xml
+++ b/AndorsTrail/res/layout/iteminfo.xml
@@ -64,6 +64,66 @@
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"
 				/>
+
+
+
+            <LinearLayout
+                android:id="@+id/compareinfo"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="@dimen/dialog_margin"
+                >
+                <TextView
+                    android:id="@+id/compareinfo_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/inventory_info"
+                    style="@style/titleWithIcon"
+                    android:drawableLeft="@drawable/equip_weapon"
+                    />
+
+                <TextView
+                    android:id="@+id/compareinfo_description"
+                    android:textStyle="italic"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/section_margin"
+                    />
+
+                <TextView
+                    android:id="@+id/compareinfo_displaytype"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginBottom="@dimen/section_margin"
+                    >
+                    <TextView
+                        android:text="@string/iteminfo_category"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        />
+                    <TextView
+                        android:id="@+id/compareinfo_category"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        />
+                </LinearLayout>
+
+                <com.gpl.rpg.AndorsTrail.view.ItemEffectsView
+                    android:id="@+id/compareinfo_effects"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    />
+            </LinearLayout>
+
+
 		</LinearLayout>
 	</ScrollView>
 

--- a/AndorsTrail/res/values/strings.xml
+++ b/AndorsTrail/res/values/strings.xml
@@ -109,6 +109,7 @@
 
 	<!-- <string name="key_required">A specific key is required to pass.</string> -->
 
+    <string name="iteminfo_title_equipped">(Equipped)</string>
 	<string name="iteminfo_category">Category: </string>
 	<string name="iteminfo_action_use">Use</string>
 	<string name="iteminfo_action_equip">Equip</string>

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ItemInfoActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ItemInfoActivity.java
@@ -35,35 +35,32 @@ public final class ItemInfoActivity extends Activity {
 		Bundle params = intent.getExtras();
 		String itemTypeID = params.getString("itemTypeID");
 		final ItemType itemType = world.itemTypes.getItemType(itemTypeID);
+        final ItemType equippedType = itemType.isEquippable()
+                ? world.model.player.inventory.getItemTypeInWearSlot(itemType.category.inventorySlot)
+                : null;
 
 		final String buttonText = params.getString("buttonText");
 		boolean buttonEnabled = params.getBoolean("buttonEnabled");
+        final Resources resources = getResources();
 
 		setContentView(R.layout.iteminfo);
 
-		TextView tv = (TextView) findViewById(R.id.iteminfo_title);
-		tv.setText(itemType.getName(world.model.player));
-		world.tileManager.setImageViewTileForSingleItemType(getResources(), tv, itemType);
+        fillTitle(world, resources, (TextView) findViewById(R.id.iteminfo_title), itemType, (itemType == equippedType));
+        fillDescription((TextView) findViewById(R.id.iteminfo_description), itemType);
+        fillCategory((TextView) findViewById(R.id.iteminfo_category), itemType);
+        fillItemEffects((ItemEffectsView) findViewById(R.id.iteminfo_effects), itemType);
+        fillDisplayType(resources, (TextView) findViewById(R.id.iteminfo_displaytype), itemType);
 
-		tv = (TextView) findViewById(R.id.iteminfo_description);
-		String description = itemType.getDescription();
-		if (description != null) {
-			tv.setText(description);
-			tv.setVisibility(View.VISIBLE);
-		} else {
-			tv.setVisibility(View.GONE);
-		}
-
-		tv = (TextView) findViewById(R.id.iteminfo_category);
-		tv.setText(itemType.category.displayName);
-
-		((ItemEffectsView) findViewById(R.id.iteminfo_effects)).update(
-				itemType.effects_equip,
-				itemType.effects_use == null ? null : Collections.singletonList(itemType.effects_use),
-				itemType.effects_hit == null ? null : Collections.singletonList(itemType.effects_hit),
-				itemType.effects_kill == null ? null : Collections.singletonList(itemType.effects_kill),
-				itemType.isWeapon()
-			);
+        if (equippedType != null && equippedType != itemType){
+            findViewById(R.id.compareinfo).setVisibility(View.VISIBLE);
+            fillTitle(world, resources, (TextView) findViewById(R.id.compareinfo_title), equippedType, true);
+            fillDescription((TextView) findViewById(R.id.compareinfo_description), equippedType);
+            fillCategory((TextView) findViewById(R.id.compareinfo_category), equippedType);
+            fillItemEffects((ItemEffectsView) findViewById(R.id.compareinfo_effects), equippedType);
+            fillDisplayType(resources, (TextView) findViewById(R.id.compareinfo_displaytype), equippedType);
+        } else {
+            findViewById(R.id.compareinfo).setVisibility(View.GONE);
+        }
 
 		Button b = (Button) findViewById(R.id.iteminfo_close);
 		b.setOnClickListener(new OnClickListener() {
@@ -93,15 +90,48 @@ public final class ItemInfoActivity extends Activity {
 			}
 		});
 
-		tv = (TextView) findViewById(R.id.iteminfo_displaytype);
-		if (itemType.isOrdinaryItem()) {
-			tv.setVisibility(View.GONE);
-		} else {
-			tv.setVisibility(View.VISIBLE);
-			final String diplayType = getDisplayTypeString(getResources(), itemType);
-			tv.setText(diplayType);
-		}
 	}
+
+    private static void fillTitle(WorldContext world, Resources resources, TextView tv, ItemType itemType, boolean equipped) {
+        tv.setText(itemType.getName(world.model.player) + (equipped ? " " + resources.getString(R.string.iteminfo_title_equipped) : ""));
+        world.tileManager.setImageViewTileForSingleItemType(resources, tv, itemType);
+
+    }
+
+    private static void fillCategory(TextView tv, ItemType itemType) {
+        tv.setText(itemType.category.displayName);
+    }
+
+    private static void fillDisplayType(Resources resources, TextView tv, ItemType itemType) {
+        if (itemType.isOrdinaryItem()) {
+            tv.setVisibility(View.GONE);
+        } else {
+            tv.setVisibility(View.VISIBLE);
+            final String diplayType = getDisplayTypeString(resources, itemType);
+            tv.setText(diplayType);
+        }
+    }
+
+    private static void fillItemEffects(ItemEffectsView iev, ItemType itemType) {
+        iev.update(
+                itemType.effects_equip,
+                itemType.effects_use == null ? null : Collections.singletonList(itemType.effects_use),
+                itemType.effects_hit == null ? null : Collections.singletonList(itemType.effects_hit),
+                itemType.effects_kill == null ? null : Collections.singletonList(itemType.effects_kill),
+                itemType.isWeapon()
+        );
+    }
+
+    private static void fillDescription(TextView tv, ItemType itemType) {
+        String description = itemType.getDescription();
+        if (description != null) {
+            tv.setText(description);
+            tv.setVisibility(View.VISIBLE);
+        } else {
+            tv.setVisibility(View.GONE);
+        }
+    }
+
 
 	public static String getDisplayTypeString(Resources res, ItemType itemType) {
 		switch (itemType.displayType) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ItemInfoActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ItemInfoActivity.java
@@ -35,32 +35,32 @@ public final class ItemInfoActivity extends Activity {
 		Bundle params = intent.getExtras();
 		String itemTypeID = params.getString("itemTypeID");
 		final ItemType itemType = world.itemTypes.getItemType(itemTypeID);
-        final ItemType equippedType = itemType.isEquippable()
-                ? world.model.player.inventory.getItemTypeInWearSlot(itemType.category.inventorySlot)
-                : null;
+		final ItemType equippedType = itemType.isEquippable()
+				? world.model.player.inventory.getItemTypeInWearSlot(itemType.category.inventorySlot)
+				: null;
 
 		final String buttonText = params.getString("buttonText");
 		boolean buttonEnabled = params.getBoolean("buttonEnabled");
-        final Resources resources = getResources();
+		final Resources resources = getResources();
 
 		setContentView(R.layout.iteminfo);
 
-        fillTitle(world, resources, (TextView) findViewById(R.id.iteminfo_title), itemType, (itemType == equippedType));
-        fillDescription((TextView) findViewById(R.id.iteminfo_description), itemType);
-        fillCategory((TextView) findViewById(R.id.iteminfo_category), itemType);
-        fillItemEffects((ItemEffectsView) findViewById(R.id.iteminfo_effects), itemType);
-        fillDisplayType(resources, (TextView) findViewById(R.id.iteminfo_displaytype), itemType);
+		fillTitle(world, resources, (TextView) findViewById(R.id.iteminfo_title), itemType, (itemType == equippedType));
+		fillDescription((TextView) findViewById(R.id.iteminfo_description), itemType);
+		fillCategory((TextView) findViewById(R.id.iteminfo_category), itemType);
+		fillItemEffects((ItemEffectsView) findViewById(R.id.iteminfo_effects), itemType);
+		fillDisplayType(resources, (TextView) findViewById(R.id.iteminfo_displaytype), itemType);
 
-        if (equippedType != null && equippedType != itemType){
-            findViewById(R.id.compareinfo).setVisibility(View.VISIBLE);
-            fillTitle(world, resources, (TextView) findViewById(R.id.compareinfo_title), equippedType, true);
-            fillDescription((TextView) findViewById(R.id.compareinfo_description), equippedType);
-            fillCategory((TextView) findViewById(R.id.compareinfo_category), equippedType);
-            fillItemEffects((ItemEffectsView) findViewById(R.id.compareinfo_effects), equippedType);
-            fillDisplayType(resources, (TextView) findViewById(R.id.compareinfo_displaytype), equippedType);
-        } else {
-            findViewById(R.id.compareinfo).setVisibility(View.GONE);
-        }
+		if (equippedType != null && equippedType != itemType){
+			findViewById(R.id.compareinfo).setVisibility(View.VISIBLE);
+			fillTitle(world, resources, (TextView) findViewById(R.id.compareinfo_title), equippedType, true);
+			fillDescription((TextView) findViewById(R.id.compareinfo_description), equippedType);
+			fillCategory((TextView) findViewById(R.id.compareinfo_category), equippedType);
+			fillItemEffects((ItemEffectsView) findViewById(R.id.compareinfo_effects), equippedType);
+			fillDisplayType(resources, (TextView) findViewById(R.id.compareinfo_displaytype), equippedType);
+		} else {
+			findViewById(R.id.compareinfo).setVisibility(View.GONE);
+		}
 
 		Button b = (Button) findViewById(R.id.iteminfo_close);
 		b.setOnClickListener(new OnClickListener() {
@@ -92,45 +92,45 @@ public final class ItemInfoActivity extends Activity {
 
 	}
 
-    private static void fillTitle(WorldContext world, Resources resources, TextView tv, ItemType itemType, boolean equipped) {
-        tv.setText(itemType.getName(world.model.player) + (equipped ? " " + resources.getString(R.string.iteminfo_title_equipped) : ""));
-        world.tileManager.setImageViewTileForSingleItemType(resources, tv, itemType);
+	private static void fillTitle(WorldContext world, Resources resources, TextView tv, ItemType itemType, boolean equipped) {
+		tv.setText(itemType.getName(world.model.player) + (equipped ? " " + resources.getString(R.string.iteminfo_title_equipped) : ""));
+		world.tileManager.setImageViewTileForSingleItemType(resources, tv, itemType);
 
-    }
+	}
 
-    private static void fillCategory(TextView tv, ItemType itemType) {
-        tv.setText(itemType.category.displayName);
-    }
+	private static void fillCategory(TextView tv, ItemType itemType) {
+		tv.setText(itemType.category.displayName);
+	}
 
-    private static void fillDisplayType(Resources resources, TextView tv, ItemType itemType) {
-        if (itemType.isOrdinaryItem()) {
-            tv.setVisibility(View.GONE);
-        } else {
-            tv.setVisibility(View.VISIBLE);
-            final String diplayType = getDisplayTypeString(resources, itemType);
-            tv.setText(diplayType);
-        }
-    }
+	private static void fillDisplayType(Resources resources, TextView tv, ItemType itemType) {
+		if (itemType.isOrdinaryItem()) {
+			tv.setVisibility(View.GONE);
+		} else {
+			tv.setVisibility(View.VISIBLE);
+			final String diplayType = getDisplayTypeString(resources, itemType);
+			tv.setText(diplayType);
+		}
+	}
 
-    private static void fillItemEffects(ItemEffectsView iev, ItemType itemType) {
-        iev.update(
-                itemType.effects_equip,
-                itemType.effects_use == null ? null : Collections.singletonList(itemType.effects_use),
-                itemType.effects_hit == null ? null : Collections.singletonList(itemType.effects_hit),
-                itemType.effects_kill == null ? null : Collections.singletonList(itemType.effects_kill),
-                itemType.isWeapon()
-        );
-    }
+	private static void fillItemEffects(ItemEffectsView iev, ItemType itemType) {
+		iev.update(
+				itemType.effects_equip,
+				itemType.effects_use == null ? null : Collections.singletonList(itemType.effects_use),
+				itemType.effects_hit == null ? null : Collections.singletonList(itemType.effects_hit),
+				itemType.effects_kill == null ? null : Collections.singletonList(itemType.effects_kill),
+				itemType.isWeapon()
+		);
+	}
 
-    private static void fillDescription(TextView tv, ItemType itemType) {
-        String description = itemType.getDescription();
-        if (description != null) {
-            tv.setText(description);
-            tv.setVisibility(View.VISIBLE);
-        } else {
-            tv.setVisibility(View.GONE);
-        }
-    }
+	private static void fillDescription(TextView tv, ItemType itemType) {
+		String description = itemType.getDescription();
+		if (description != null) {
+			tv.setText(description);
+			tv.setVisibility(View.VISIBLE);
+		} else {
+			tv.setVisibility(View.GONE);
+		}
+	}
 
 
 	public static String getDisplayTypeString(Resources res, ItemType itemType) {


### PR DESCRIPTION
When info is requested for an equippable item, the info for the corresponding equipped item (if any) is displayed under the info for the requested item. If the requested item is already equipped, then no comparison is made, but the iteminfo_title_equipped string resource is appended to the title.

* It will show the corresponding equipped item -- eg helmet to helmet, boots to boots, etc. 
* If you've dual-wielded and you look a shield, it will compare to the weapon in the off-hand.
* If you look at the weapon in your shield hand, it will compare to the weapon in your weapon hand.
