### PR TITLE
Fixed bug where game crashed if some skills had no requirements when sorted.

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/view/SkillListAdapter.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/view/SkillListAdapter.java
@@ -197,6 +197,10 @@ public final class SkillListAdapter extends ArrayAdapter<SkillInfo> {
 						&& item2.canLevelUpSkillTo(player, player.getSkillLevel(item2.id) +1))
 					return 1;
 				else { // Then compare by number of requirements (complexity)
+					if(item1.levelupRequirements == null)
+						return -1;
+					if(item2.levelupRequirements == null)
+						return 1;
 					if(item1.levelupRequirements.length< item2.levelupRequirements.length)
 						return -1;
 					else if(item1.levelupRequirements.length > item2.levelupRequirements.length)


### PR DESCRIPTION
I only noticed it after levelling up and the code went into the 2nd layer of conditionals.

I re-tested it and tried all combinations of sorting back and forth, and there's no problem now.

I hadn't taken into account that the skillRequirements in SkillInfo are occasionally declared as _null_.

P.S. Stoutford is looking very pretty!