### PR TITLE
End round at end of combat

### DIFF
--- a/AndorsTrail/res/values/authors.xml
+++ b/AndorsTrail/res/values/authors.xml
@@ -19,6 +19,7 @@
 		Additional programming by Lucas Delvallet&lt;br /&gt;
 		Additional programming by Florian Doublet&lt;br /&gt;
 		Additional programming by M.H. Alkotob&lt;br /&gt;
+		Additional programming by Olivier Dragon&lt;br /&gt;
 		Additional graphics by Karvis&lt;br /&gt;
 		Russian translation by Dreamer..., e.solodookhin, shell.andor, konstmih, istasman, Aleksey Kabanov, Alexander Zubok, Paul Sulemenkov and dromoz&lt;br /&gt;
 		Italian translation by k6blue, liogiu, Joker and Andrea Luciano Damico&lt;br /&gt;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -457,14 +457,14 @@ public final class CombatController implements VisualEffectCompletedCallback {
 	}
 
 	private void newPlayerTurn(boolean isFirstRound) {
-		if (canExitCombat()) {
-			exitCombat(true);
-			return;
-		}
 		controllers.actorStatsController.setActorMaxAP(world.model.player);
 		if (!isFirstRound) controllers.gameRoundController.onNewPlayerRound();
 		world.model.uiSelections.isPlayersCombatTurn = true;
 		combatTurnListeners.onNewPlayerTurn();
+		if (canExitCombat()) {
+			exitCombat(true);
+			return;
+		}
 	}
 
 	private static boolean hasCriticalAttack(Actor attacker, Actor target) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -58,7 +58,7 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		combatTurnListeners.onCombatEnded();
 		world.model.uiSelections.selectedPosition = null;
 		world.model.uiSelections.selectedMonster = null;
-		controllers.gameRoundController.resetRoundTimers();
+		endOfCombatRound();
 		if (pickupLootBags && totalExpThisFight > 0) {
 			controllers.itemController.lootMonsterBags(killedMonsterBags, totalExpThisFight);
 		} else {
@@ -555,6 +555,12 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		for (ItemTraits_OnUse e : onHitEffects) {
 			controllers.actorStatsController.applyUseEffect(attacker, target, e);
 		}
+	}
+
+	public void endOfCombatRound() {
+		world.model.worldData.tickWorldTime();
+		controllers.actorStatsController.applyConditionsToPlayer(world.model.player, false);
+		controllers.actorStatsController.applyConditionsToMonsters(world.model.currentMap, true);
 	}
 
 	public void monsterSteppedOnPlayer(Monster m) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -457,14 +457,14 @@ public final class CombatController implements VisualEffectCompletedCallback {
 	}
 
 	private void newPlayerTurn(boolean isFirstRound) {
-		controllers.actorStatsController.setActorMaxAP(world.model.player);
-		if (!isFirstRound) controllers.gameRoundController.onNewPlayerRound();
-		world.model.uiSelections.isPlayersCombatTurn = true;
-		combatTurnListeners.onNewPlayerTurn();
 		if (canExitCombat()) {
 			exitCombat(true);
 			return;
 		}
+		controllers.actorStatsController.setActorMaxAP(world.model.player);
+		if (!isFirstRound) controllers.gameRoundController.onNewPlayerRound();
+		world.model.uiSelections.isPlayersCombatTurn = true;
+		combatTurnListeners.onNewPlayerTurn();
 	}
 
 	private static boolean hasCriticalAttack(Actor attacker, Actor target) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -55,7 +55,6 @@ public final class CombatController implements VisualEffectCompletedCallback {
 	public void exitCombat(boolean pickupLootBags) {
 		setCombatSelection(null, null);
 		world.model.uiSelections.isInCombat = false;
-		combatTurnListeners.onCombatEnded();
 		world.model.uiSelections.selectedPosition = null;
 		world.model.uiSelections.selectedMonster = null;
 		endOfCombatRound();
@@ -558,7 +557,9 @@ public final class CombatController implements VisualEffectCompletedCallback {
 	}
 
 	public void endOfCombatRound() {
+		combatTurnListeners.onCombatEnded();
 		world.model.worldData.tickWorldTime();
+		controllers.gameRoundController.resetRoundTimers();
 		controllers.actorStatsController.applyConditionsToPlayer(world.model.player, false);
 		controllers.actorStatsController.applyConditionsToMonsters(world.model.currentMap, true);
 	}


### PR DESCRIPTION
As discussed on the forums. Tested with a lot of fighting. Regen is unaffected as it's not an actor condition and is handled separately. Sustenance and negative effects such as bleeding and poison now apply immediately at the end of combat. Corpse eater still works as before.