### PR TITLE
Fixed typos

### DIFF
--- a/AndorsTrail/res/raw/conversationlist_crossglen_leonid.json
+++ b/AndorsTrail/res/raw/conversationlist_crossglen_leonid.json
@@ -102,7 +102,7 @@
     },
     {
         "id":"leonid_crossglen4",
-        "message":"Lord Geomyr issued a statement regarding the unlawful use of Bonemeal as healing substance. Some villagers argued that we should oppose Lord Geomyr's word and still use it.",
+        "message":"Lord Geomyr issued a statement regarding the unlawful use of bonemeal as healing substance. Some villagers argued that we should oppose Lord Geomyr's word and still use it.",
         "replies":[
             {
                 "text":"N",
@@ -176,7 +176,7 @@
     },
     {
         "id":"leonid_crossglen9",
-        "message":"In the meantime, we've banned all use of Bonemeal as a healing substance.",
+        "message":"In the meantime, we've banned all use of bonemeal as a healing substance.",
         "replies":[
             {
                 "text":"Thank you for the information. There was something more I wanted to ask you.",

--- a/AndorsTrail/res/raw/conversationlist_crossglen_tharal.json
+++ b/AndorsTrail/res/raw/conversationlist_crossglen_tharal.json
@@ -8,7 +8,7 @@
                 "nextPhraseID":"S"
             },
             {
-                "text":"What can you tell me about Bonemeal?",
+                "text":"What can you tell me about bonemeal?",
                 "nextPhraseID":"tharal_bonemeal_select",
                 "requires":[
                     {
@@ -139,7 +139,7 @@
     },
     {
         "id":"tharal_bonemeal7",
-        "message":"I know someone that still has a supply of Bonemeal if you are interested. Go talk to Thoronir, a fellow priest in Fallhaven. Tell him my password 'Glow of the Shadow'.",
+        "message":"I know someone that still has a supply of bonemeal if you are interested. Go talk to Thoronir, a fellow priest in Fallhaven. Tell him my password 'Glow of the Shadow'.",
         "replies":[
             {
                 "text":"Thanks, bye",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_church.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_church.json
@@ -16,7 +16,7 @@
                 "nextPhraseID":"thoronir_church_1"
             },
             {
-                "text":"Are the Bonemeal potions ready yet?",
+                "text":"Are the bonemeal potions ready yet?",
                 "nextPhraseID":"thoronir_trade_bonemeal",
                 "requires":[
                     {
@@ -141,7 +141,7 @@
     },
     {
         "id":"thoronir_tharal_2",
-        "message":"Shhh, we shouldn't talk so loud about using Bonemeal. As you know, Lord Geomyr issued a ban on all use of Bonemeal.",
+        "message":"Shhh, we shouldn't talk so loud about using bonemeal. As you know, Lord Geomyr issued a ban on all use of bonemeal.",
         "replies":[
             {
                 "text":"N",
@@ -161,7 +161,7 @@
     },
     {
         "id":"thoronir_tharal_4",
-        "message":"Do you think you could find me 5 skeletal bones that I can use for mixing a Bonemeal potion? The bonemeal is very potent in healing old wounds.",
+        "message":"Do you think you could find me 5 skeletal bones that I can use for mixing a bonemeal potion? The bonemeal is very potent in healing old wounds.",
         "replies":[
             {
                 "text":"Sure, I might be able to do that.",
@@ -216,11 +216,11 @@
     },
     {
         "id":"thoronir_complete_2",
-        "message":"Give me some time to mix the Bonemeal potion. It is a very potent healing potion. Come back in a little while."
+        "message":"Give me some time to mix the bonemeal potion. It is a very potent healing potion. Come back in a little while."
     },
     {
         "id":"thoronir_trade_bonemeal",
-        "message":"Yes, the Bonemeal potions are ready. Please use them with care, and don't let the guards see you. We are not actually allowed to use them anymore.",
+        "message":"Yes, the bonemeal potions are ready. Please use them with care, and don't let the guards see you. We are not actually allowed to use them anymore.",
         "replies":[
             {
                 "text":"Let me see what potions you have made so far.",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_potions.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_potions.json
@@ -274,7 +274,7 @@
         "message":"Poison glands however, can be a bit trickier to find. I don't know really, but any poisonous creature might do. Maybe some snakes around here are poisonous?",
         "replies":[
             {
-                "text":"I'll be right back with those ingredients for you.",
+                "text":"I'll be right back with those ingredients.",
                 "nextPhraseID":"fallhaven_pot_antifoodp6"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_south.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_south.json
@@ -174,7 +174,7 @@
     },
     {
         "id":"fallhaven_lumberjack_8",
-        "message":"Yes exactly. If you would do me that favor I will gladly cut away the trees and receive payment afterwards. Just head north to the Crossroads Guardhouse and then head eastwards down the Duleian Road. That's where I lost my axe. And look out for that wolf pack!",
+        "message":"Yes exactly. If you would do me that favor I will gladly cut away the trees and receive payment afterwards. Just head north to the Crossroads guardhouse and then head eastwards down the Duleian Road. That's where I lost my axe. And look out for that wolf pack!",
         "replies":[
             {
                 "text":"Sounds simple enough. On my way.",
@@ -300,7 +300,7 @@
                 "nextPhraseID":"S"
             },
             {
-                "text":"Nevermind. I don't need your services for now.",
+                "text":"Never mind. I don't need your services for now.",
                 "nextPhraseID":"X"
             }
         ]
@@ -310,7 +310,7 @@
         "message":"Thank you for bringing me back my axe!",
         "replies":[
             {
-                "text":"So will you cut away those trees which block the old pathway?",
+                "text":"So will you cut away those trees that block the old pathway?",
                 "nextPhraseID":"fallhaven_lumberjack_11"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_foamingflask.json
+++ b/AndorsTrail/res/raw/conversationlist_foamingflask.json
@@ -61,7 +61,7 @@
         "message":"I am Torilo, the proprietor of this establishment. Please have a seat anywhere you like.",
         "replies":[
             {
-                "text":"Can I see what you have available in food and drink?",
+                "text":"Can I see what you have available for food and drink?",
                 "nextPhraseID":"torilo_shop_1"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_foamingflask_guards.json
+++ b/AndorsTrail/res/raw/conversationlist_foamingflask_guards.json
@@ -24,7 +24,7 @@
         "message":"We will stand tall. Feygard, city of peace!",
         "replies":[
             {
-                "text":"I had better be going",
+                "text":"I had better be going.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_graveyard1.json
+++ b/AndorsTrail/res/raw/conversationlist_graveyard1.json
@@ -137,7 +137,7 @@
     },
     {
         "id":"algore_50",
-        "message":"Still, I did not give up. I thought that if I opened the chest and gave its treasure as a gift to Lord Geomyr, I could plead with him to lift the Bonemeal ban in time to save my daughter. It sounds stupid but I was desperate.",
+        "message":"Still, I did not give up. I thought that if I opened the chest and gave its treasure as a gift to Lord Geomyr, I could plead with him to lift the bonemeal ban in time to save my daughter. It sounds stupid but I was desperate.",
         "replies":[
             {
                 "text":"N",
@@ -1617,7 +1617,7 @@
     },
     {
         "id":"algore_41",
-        "message":"I had to do something. I went to Fallhaven and begged Thoronir to make me a Bonemeal potion. Although it would have cured my daughter completely, he refused because Lord Geomyr banned all use of Bonemeal as a healing substance!\n(Hagale takes another long swig from the bottle of Lowyna\u2019s special brew and finishes it. He proceeds to open the second the bottle.)",
+        "message":"I had to do something. I went to Fallhaven and begged Thoronir to make me a bonemeal potion. Although it would have cured my daughter completely, he refused because Lord Geomyr banned all use of bonemeal as a healing substance!\n(Hagale takes another long swig from the bottle of Lowyna\u2019s special brew and finishes it. He proceeds to open the second the bottle.)",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_halvor_surprise.json
+++ b/AndorsTrail/res/raw/conversationlist_halvor_surprise.json
@@ -1386,7 +1386,7 @@
     },
     {
         "id":"halvor_mlake_leaving",
-        "message":"OK. Nevermind. I'll try to find long bones elsewhere.",
+        "message":"OK. Never mind. I'll try to find long bones elsewhere.",
         "replies":[
             {
                 "text":"Yeah. Go far. Very far.",

--- a/AndorsTrail/res/raw/conversationlist_jan.json
+++ b/AndorsTrail/res/raw/conversationlist_jan.json
@@ -114,7 +114,7 @@
         "message":"That's when it happened.\n\n*sob*\n\nOh what have we done?",
         "replies":[
             {
-                "text":"Please go on",
+                "text":"Please go on.",
                 "nextPhraseID":"jan_default9"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_kaori.json
+++ b/AndorsTrail/res/raw/conversationlist_kaori.json
@@ -167,7 +167,7 @@
     },
     {
         "id":"kaori_13",
-        "message":"I would really like to have a few more of those. If you can bring me 10 Bonemeal potions, I might consider trusting you a bit more.",
+        "message":"I would really like to have a few more of those. If you can bring me 10 bonemeal potions, I might consider trusting you a bit more.",
         "replies":[
             {
                 "text":"Ok. I will get some potions for you.",
@@ -199,7 +199,7 @@
     },
     {
         "id":"kaori_return_1",
-        "message":"Hello again. Have you found those 10 Bonemeal potions I asked for?",
+        "message":"Hello again. Have you found those 10 bonemeal potions I asked for?",
         "replies":[
             {
                 "text":"No, I am still looking for them.",

--- a/AndorsTrail/res/raw/conversationlist_loneford_4.json
+++ b/AndorsTrail/res/raw/conversationlist_loneford_4.json
@@ -158,7 +158,7 @@
                 ]
             },
             {
-                "text":"Never mind then",
+                "text":"Never mind then.",
                 "nextPhraseID":"X"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_ogam.json
+++ b/AndorsTrail/res/raw/conversationlist_ogam.json
@@ -29,7 +29,7 @@
                 "nextPhraseID":"ogam_3"
             },
             {
-                "text":"Please go on",
+                "text":"Please go on.",
                 "nextPhraseID":"ogam_3"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_v0612graves.json
+++ b/AndorsTrail/res/raw/conversationlist_v0612graves.json
@@ -105,7 +105,7 @@
     },
     {
         "id":"sign_catacombs3_grave2",
-        "message":"(The stench coming from the grave is unbearable. Something must have disturbed the grave recently)"
+        "message":"(The stench coming from the grave is unbearable. Something must have disturbed the grave recently.)"
     },
     {
         "id":"sign_catacombs4_grave1",
@@ -161,7 +161,7 @@
     },
     {
         "id":"sign_bwm52_papers1",
-        "message":"(On the floor is what looks like some torn out pages from a book)"
+        "message":"(On the floor is what looks like some torn out pages from a book.)"
     },
     {
         "id":"sign_bwm52_papers2",

--- a/AndorsTrail/res/raw/conversationlist_vilegard_shops.json
+++ b/AndorsTrail/res/raw/conversationlist_vilegard_shops.json
@@ -90,7 +90,7 @@
                 ]
             },
             {
-                "text":"On the body of something called the Hira'zinn, I found this peculiar sword. Do you know anything about it?.",
+                "text":"On the body of something called the Hira'zinn, I found this peculiar sword. Do you know anything about it?",
                 "nextPhraseID":"vilegard_smith_xul_1",
                 "requires":[
                     {
@@ -145,7 +145,7 @@
                 ]
             },
             {
-                "text":"On the body of something called the Hira'zinn, I found this peculiar sword. Do you know anything about it?.",
+                "text":"On the body of something called the Hira'zinn, I found this peculiar sword. Do you know anything about it?",
                 "nextPhraseID":"vilegard_shop_notrust_2",
                 "requires":[
                     {

--- a/AndorsTrail/res/raw/questlist_v0610.json
+++ b/AndorsTrail/res/raw/questlist_v0610.json
@@ -52,7 +52,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"On the road to Carn Tower, west of the crossroads guardhouse, I met a group of woodcutters led by Hadracor. Hadracor wants me to help him get revenge on some wasps that were attacking them while they were cutting down the forest. To help them get revenge, I should look for giant wasps near their encampment and bring him at least five giant wasp wings."
+                "logText":"On the road to Carn Tower, west of the Crossroads guardhouse, I met a group of woodcutters led by Hadracor. Hadracor wants me to help him get revenge on some wasps that were attacking them while they were cutting down the forest. To help them get revenge, I should look for giant wasps near their encampment and bring him at least five giant wasp wings."
             },
             {
                 "progress":20,
@@ -132,7 +132,7 @@
             },
             {
                 "progress":20,
-                "logText":"I have agreed to help Benbyr find Tinlyn's sheep and kill all eight of them. I should go look for them in the fields northwest of the crossroads guardhouse."
+                "logText":"I have agreed to help Benbyr find Tinlyn's sheep and kill all eight of them. I should go look for them in the fields northwest of the Crossroads guardhouse."
             },
             {
                 "progress":21,


### PR DESCRIPTION
Hello @Zukero 
I found some typos during translation. Some of them are fixed to be identical with already existing sentences. _Crossroads guardhouse_ is written now with uppercase "C" and lowercase "g" in every sentences, and _bonemeal_ is written with lowercase "b" in every sentences. These were used differently, but now they are consistent.
Can you please sync the translatable strings with Weblate after you merge this PR to make the fixed strings available for translation?