### PR TITLE
Fixed spelling for OK

### DIFF
--- a/AndorsTrail/res/raw/conversationlist_ailshara.json
+++ b/AndorsTrail/res/raw/conversationlist_ailshara.json
@@ -86,7 +86,7 @@
         "message":"Oh yes. You see, these Feygard patrol guards carry some really interesting things. They don't seem to care much if some of their shipments.. well, disappear.",
         "replies":[
             {
-                "text":"Ok, let me see what you have.",
+                "text":"OK, let me see what you have.",
                 "nextPhraseID":"S"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_algangror.json
+++ b/AndorsTrail/res/raw/conversationlist_algangror.json
@@ -530,11 +530,11 @@
         "message":"Therefore, I ask of you not to reveal my whereabouts to them.",
         "replies":[
             {
-                "text":"Ok.",
+                "text":"OK.",
                 "nextPhraseID":"algangror_remgard_6"
             },
             {
-                "text":"(Lie) Ok.",
+                "text":"(Lie) OK.",
                 "nextPhraseID":"algangror_remgard_6"
             }
         ]
@@ -544,7 +544,7 @@
         "message":"Thank you. Under no circumstances should you tell them where I am. They will most likely try to persuade you into revealing my location.",
         "replies":[
             {
-                "text":"Ok.",
+                "text":"OK.",
                 "nextPhraseID":"algangror_remgard_7"
             }
         ]
@@ -829,11 +829,11 @@
         "message":"The world around you seems to move a bit slower when you wear it.",
         "replies":[
             {
-                "text":"Ok. I will help you with your task.",
+                "text":"OK. I will help you with your task.",
                 "nextPhraseID":"algangror_task2_6"
             },
             {
-                "text":"Ok, I'll help. I'm always interested in new items.",
+                "text":"OK, I'll help. I'm always interested in new items.",
                 "nextPhraseID":"algangror_task2_6"
             },
             {
@@ -858,11 +858,11 @@
         "message":"As I said, I cannot tell you what task I have in mind, or my reasoning behind it until you are done. I would need your total .. cooperation with this.",
         "replies":[
             {
-                "text":"Ok. I will agree to help you with your task.",
+                "text":"OK. I will agree to help you with your task.",
                 "nextPhraseID":"algangror_task2_6"
             },
             {
-                "text":"Ok, I'll help. I'm always interested in new items.",
+                "text":"OK, I'll help. I'm always interested in new items.",
                 "nextPhraseID":"algangror_task2_6"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_blackwater_harlenn.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_harlenn.json
@@ -467,7 +467,7 @@
         "message":"Gain? Our trust of course. You would always be welcome here in our camp. Our traders have some excellent equipment.",
         "replies":[
             {
-                "text":"Ok, I'll help you deal with them.",
+                "text":"OK, I'll help you deal with them.",
                 "nextPhraseID":"harlenn_prim_6"
             },
             {
@@ -499,7 +499,7 @@
     },
     {
         "id":"harlenn_20",
-        "message":"Ok, this is the plan. I want you to go talk to Guthbered down in Prim, and give him our ultimatum:",
+        "message":"OK, this is the plan. I want you to go talk to Guthbered down in Prim, and give him our ultimatum:",
         "replies":[
             {
                 "text":"N",
@@ -694,7 +694,7 @@
     },
     {
         "id":"harlenn_talkedto_guth_4",
-        "message":"Ok, this leaves us with no choice. We will have to step this up to another level.",
+        "message":"OK, this leaves us with no choice. We will have to step this up to another level.",
         "replies":[
             {
                 "text":"N",
@@ -1035,7 +1035,7 @@
     },
     {
         "id":"harlenn_sentbyprim_7",
-        "message":"Ok, you have convinced me. I will leave this settlement for another to find my home. The survival of my people here is more important than me.",
+        "message":"OK, you have convinced me. I will leave this settlement for another to find my home. The survival of my people here is more important than me.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_blackwater_herec.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_herec.json
@@ -130,7 +130,7 @@
         "message":"Let's say, five of those claws should be enough.",
         "replies":[
             {
-                "text":"Ok, sounds easy enough. I'll get you your 5 white wyrm claws.",
+                "text":"OK, sounds easy enough. I'll get you your 5 white wyrm claws.",
                 "nextPhraseID":"herec_10"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_blackwater_throdna.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_throdna.json
@@ -275,7 +275,7 @@
     },
     {
         "id":"throdna_19",
-        "message":"Ok. Find me the pieces of the ritual that the former messenger carried on him. They should be found somewhere on the path up to Blackwater Mountain.",
+        "message":"OK. Find me the pieces of the ritual that the former messenger carried on him. They should be found somewhere on the path up to Blackwater Mountain.",
         "replies":[
             {
                 "text":"I will return with your parts of the ritual.",

--- a/AndorsTrail/res/raw/conversationlist_buceth.json
+++ b/AndorsTrail/res/raw/conversationlist_buceth.json
@@ -113,7 +113,7 @@
         "message":"Let me ask you something first, and we might talk after that.",
         "replies":[
             {
-                "text":"Ok, what?",
+                "text":"OK, what?",
                 "nextPhraseID":"buceth_4"
             },
             {
@@ -342,7 +342,7 @@
         "message":"I am sorry to hear that. You should make up your mind and return to me once you have done so. Then we might be able to talk more.",
         "replies":[
             {
-                "text":"Ok, goodbye.",
+                "text":"OK, goodbye.",
                 "nextPhraseID":"X"
             },
             {
@@ -472,7 +472,7 @@
         "message":"You wanted to know about some business that you accuse me of. Since you have no proof, I will claim innocence. I know that my conscience is clean.",
         "replies":[
             {
-                "text":"Ok, goodbye.",
+                "text":"OK, goodbye.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_1.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_1.json
@@ -152,7 +152,7 @@
                 "nextPhraseID":"bwm_agent_1_13"
             },
             {
-                "text":"Ok, I'll go through the pitch-black mine.",
+                "text":"OK, I'll go through the pitch-black mine.",
                 "nextPhraseID":"bwm_agent_1_14"
             }
         ]
@@ -172,7 +172,7 @@
         "message":"Let's meet at the other side of this mine shaft.",
         "replies":[
             {
-                "text":"Ok. You crawl through the shaft, and I'll go below. See you on the other side!",
+                "text":"OK. You crawl through the shaft, and I'll go below. See you on the other side!",
                 "nextPhraseID":"R"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_2.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_2.json
@@ -80,7 +80,7 @@
         "message":"Once we exit this mine, it is very important that you go directly east from there. Do not travel to other places other than going east now!",
         "replies":[
             {
-                "text":"Ok, I'll go east once I have exited the mine. Got it.",
+                "text":"OK, I'll go east once I have exited the mine. Got it.",
                 "nextPhraseID":"bwm_agent_2_7"
             },
             {
@@ -94,7 +94,7 @@
         "message":"I'll wait for you by the steps up to the mountain pass. See you there!\n\nRemember, go east once you exit the mine.",
         "replies":[
             {
-                "text":"Ok, see you there!",
+                "text":"OK, see you there!",
                 "nextPhraseID":"R"
             }
         ],
@@ -143,11 +143,11 @@
         "message":"No no, just head east and I'll explain everything to you once we get to the Blackwater mountain settlement.",
         "replies":[
             {
-                "text":"Ok, I promise to head east once we exit the mine.",
+                "text":"OK, I promise to head east once we exit the mine.",
                 "nextPhraseID":"bwm_agent_2_7"
             },
             {
-                "text":"(Lie) Ok, I promise to head east once we exit the mine.",
+                "text":"(Lie) OK, I promise to head east once we exit the mine.",
                 "nextPhraseID":"bwm_agent_2_7"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_3.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_3.json
@@ -63,7 +63,7 @@
         "message":"Beware of the nasty monsters, they can really cause some harm!",
         "replies":[
             {
-                "text":"Ok, I will follow this path up the mountain.",
+                "text":"OK, I will follow this path up the mountain.",
                 "nextPhraseID":"R"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_4.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_4.json
@@ -70,7 +70,7 @@
         "message":"Meet me further up the mountain, and we will talk more.",
         "replies":[
             {
-                "text":"Ok, see you there.",
+                "text":"OK, see you there.",
                 "nextPhraseID":"R"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_5.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_5.json
@@ -72,7 +72,7 @@
         "message":"Now hurry. We are almost there. Follow the snowy path to the north, and you should reach the settlement in no time.",
         "replies":[
             {
-                "text":"Ok, I will follow the path to the north, further up the mountain.",
+                "text":"OK, I will follow the path to the north, further up the mountain.",
                 "nextPhraseID":"R"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_6.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_6.json
@@ -50,7 +50,7 @@
         "message":"Go ahead, I will meet you inside.",
         "replies":[
             {
-                "text":"Ok, see you inside.",
+                "text":"OK, see you inside.",
                 "nextPhraseID":"R"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_charwood1.json
+++ b/AndorsTrail/res/raw/conversationlist_charwood1.json
@@ -75,7 +75,7 @@
                 "nextPhraseID":"charwd_guard4"
             },
             {
-                "text":"Ok, I'll go talk to her.",
+                "text":"OK, I'll go talk to her.",
                 "nextPhraseID":"charwd_guard3"
             }
         ]
@@ -89,7 +89,7 @@
         "message":"Behind me is the path up to the Charwood mining town. You really should go talk to Maevalia though. She's inside the cabin.",
         "replies":[
             {
-                "text":"Ok, I'll go talk to her.",
+                "text":"OK, I'll go talk to her.",
                 "nextPhraseID":"charwd_guard3"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_crossglen_gruil.json
+++ b/AndorsTrail/res/raw/conversationlist_crossglen_gruil.json
@@ -54,7 +54,7 @@
                 ]
             },
             {
-                "text":"Ok, I'll bring one.",
+                "text":"OK, I'll bring one.",
                 "nextPhraseID":"X"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_crossglen_leta.json
+++ b/AndorsTrail/res/raw/conversationlist_crossglen_leta.json
@@ -103,7 +103,7 @@
         "message":"I'm hiding here from my wife Leta. She is always getting angry at me for not helping out on the farm. Please don't tell her that I'm here.",
         "replies":[
             {
-                "text":"Ok.",
+                "text":"OK.",
                 "nextPhraseID":"X"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_crossglen_odair.json
+++ b/AndorsTrail/res/raw/conversationlist_crossglen_odair.json
@@ -84,7 +84,7 @@
         "message":"I need you to get into that cave and kill the large rat, that way maybe we can stop the rat infestation in the cave and start using it as our old supply cave again.",
         "replies":[
             {
-                "text":"Ok.",
+                "text":"OK.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_crossglen_tharal.json
+++ b/AndorsTrail/res/raw/conversationlist_crossglen_tharal.json
@@ -78,7 +78,7 @@
                 ]
             },
             {
-                "text":"Ok, I'll bring them.",
+                "text":"OK, I'll bring them.",
                 "nextPhraseID":"X"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_crossroads_1.json
+++ b/AndorsTrail/res/raw/conversationlist_crossroads_1.json
@@ -41,7 +41,7 @@
     },
     {
         "id":"fanamor_4",
-        "message":"Oh, who am I kidding. Ok, I was trying to get through the forest here and got ambushed by these anklebiters.",
+        "message":"Oh, who am I kidding. OK, I was trying to get through the forest here and got ambushed by these anklebiters.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_crossroads_2.json
+++ b/AndorsTrail/res/raw/conversationlist_crossroads_2.json
@@ -112,7 +112,7 @@
         "message":"So, if you will excuse me, I really need my well deserved rest here. Without you bothering me.",
         "replies":[
             {
-                "text":"Ok, I will leave.",
+                "text":"OK, I will leave.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_crossroads_3.json
+++ b/AndorsTrail/res/raw/conversationlist_crossroads_3.json
@@ -93,7 +93,7 @@
         "message":"Back there? Oh, nothing.",
         "replies":[
             {
-                "text":"Ok, never mind then.",
+                "text":"OK, never mind then.",
                 "nextPhraseID":"X"
             },
             {
@@ -107,7 +107,7 @@
         "message":"Lead? Oh nowhere. Nothing back there at all.",
         "replies":[
             {
-                "text":"Ok, never mind then.",
+                "text":"OK, never mind then.",
                 "nextPhraseID":"X"
             },
             {
@@ -121,7 +121,7 @@
         "message":"Oh no, no. Nothing interesting here. Move along now.",
         "replies":[
             {
-                "text":"Ok, never mind then.",
+                "text":"OK, never mind then.",
                 "nextPhraseID":"X"
             },
             {
@@ -145,7 +145,7 @@
         "message":"No.",
         "replies":[
             {
-                "text":"Ok, never mind then.",
+                "text":"OK, never mind then.",
                 "nextPhraseID":"X"
             },
             {
@@ -159,7 +159,7 @@
         "message":"No.",
         "replies":[
             {
-                "text":"Ok, never mind then.",
+                "text":"OK, never mind then.",
                 "nextPhraseID":"X"
             },
             {
@@ -173,11 +173,11 @@
         "message":"Look, you are not getting back there, and there is nothing to see back there.",
         "replies":[
             {
-                "text":"Ok, never mind then.",
+                "text":"OK, never mind then.",
                 "nextPhraseID":"X"
             },
             {
-                "text":"Ok, final offer, 800 gold? That's a fortune.",
+                "text":"OK, final offer, 800 gold? That's a fortune.",
                 "nextPhraseID":"crossroads_backguard_8"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_debug.json
+++ b/AndorsTrail/res/raw/conversationlist_debug.json
@@ -170,7 +170,7 @@
         "nextPhraseID": "X"
       }
     ],
-    "message": "Okay. But only because it's you M. Coder."
+    "message": "OK. But only because it's you M. Coder."
   },
   {
     "id": "debugrequires10gold_3",
@@ -263,7 +263,7 @@
     },
     {
     	"id":"npc3_2",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -274,7 +274,7 @@
 	},
     {
     	"id":"npc3_3",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -285,7 +285,7 @@
 	},
     {
     	"id":"npc3_4",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -296,7 +296,7 @@
 	},
     {
     	"id":"npc3_5",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -307,7 +307,7 @@
 	},
     {
     	"id":"npc3_6",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -318,7 +318,7 @@
 	},
     {
     	"id":"npc3_7",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -329,7 +329,7 @@
 	},
     {
     	"id":"npc3_8",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -340,7 +340,7 @@
 	},
     {
     	"id":"npc3_9",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -351,7 +351,7 @@
 	},
     {
     	"id":"npc3_10",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",
@@ -362,7 +362,7 @@
 	},
     {
     	"id":"npc3_11",
-    	"message":"Ok.",
+    	"message":"OK.",
     	"rewards":[
         	{
             	"rewardType":"changeMapFilter",

--- a/AndorsTrail/res/raw/conversationlist_elwyl.json
+++ b/AndorsTrail/res/raw/conversationlist_elwyl.json
@@ -134,7 +134,7 @@
                 "nextPhraseID":"elwyl_2"
             },
             {
-                "text":"Ok, I'll leave.",
+                "text":"OK, I'll leave.",
                 "nextPhraseID":"X"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_arcir.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_arcir.json
@@ -46,7 +46,7 @@
         "message":"Oh, you found my statue in the basement?\n\nYes, Elythara is my protector.",
         "replies":[
             {
-                "text":"Okay.",
+                "text":"OK.",
                 "nextPhraseID":"arcir_anythingelse"
             }
         ]
@@ -67,7 +67,7 @@
                 ]
             },
             {
-                "text":"Okay.",
+                "text":"OK.",
                 "nextPhraseID":"arcir_anythingelse"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_athamyr.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_athamyr.json
@@ -62,7 +62,7 @@
                 ]
             },
             {
-                "text":"Ok, I'll go get some.",
+                "text":"OK, I'll go get some.",
                 "nextPhraseID":"X"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_bucus.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_bucus.json
@@ -97,7 +97,7 @@
     },
     {
         "id":"bucus_umar_1",
-        "message":"Ok kid. You've proven yourself to me. Yes, I saw some other kid by that description running around here a few days ago.",
+        "message":"OK kid. You've proven yourself to me. Yes, I saw some other kid by that description running around here a few days ago.",
         "replies":[
             {
                 "text":"N",
@@ -120,7 +120,7 @@
         "message":"Anyway, that's all I know. You should go talk to Umar, he probably knows more. Down that hatch over there.",
         "replies":[
             {
-                "text":"Ok, bye.",
+                "text":"OK, bye.",
                 "nextPhraseID":"X"
             }
         ],
@@ -134,7 +134,7 @@
     },
     {
         "id":"bucus_thieves_1",
-        "message":"Who told you that? Argh.\n\nOk so you found us. Now what?",
+        "message":"Who told you that? Argh.\n\nOK so you found us. Now what?",
         "replies":[
             {
                 "text":"Can I join the Thieves' Guild?",
@@ -158,7 +158,7 @@
     },
     {
         "id":"bucus_thieves_3",
-        "message":"Ok, tell you what kid. Do a task for me and maybe I'll consider giving you more info.",
+        "message":"OK, tell you what kid. Do a task for me and maybe I'll consider giving you more info.",
         "replies":[
             {
                 "text":"What kind of task are we talking about?",
@@ -175,7 +175,7 @@
         "message":"Bring me the key of Luthor and we can talk more. I don't know anything about the key itself, but rumor has it that it is located somewhere in the catacombs beneath Fallhaven Church.",
         "replies":[
             {
-                "text":"Ok, sounds easy enough.",
+                "text":"OK, sounds easy enough.",
                 "nextPhraseID":"X"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_church.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_church.json
@@ -127,7 +127,7 @@
         "message":"No one is allowed down in the catacombs, except for Athamyr, my apprentice. He is the only one that has been down there for years.",
         "replies":[
             {
-                "text":"Ok, I might go see him.",
+                "text":"OK, I might go see him.",
                 "nextPhraseID":"thoronir_default"
             }
         ],
@@ -185,7 +185,7 @@
         "message":"Thank you, please come back soon. I heard there were some undead near an old abandoned house just north of Fallhaven. Maybe you can check for bones there?",
         "replies":[
             {
-                "text":"Ok, I'll go check there.",
+                "text":"OK, I'll go check there.",
                 "nextPhraseID":"thoronir_default"
             }
         ],
@@ -255,7 +255,7 @@
         "message":"Nooo, you shall not pass!",
         "replies":[
             {
-                "text":"Ok. Let's fight.",
+                "text":"OK. Let's fight.",
                 "nextPhraseID":"F"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_drunk.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_drunk.json
@@ -25,7 +25,7 @@
     },
     {
         "id":"fallhaven_drunk_3_1",
-        "message":"Oh, sir. I'm not causing any trouble anymore, see? I sits outside now as you says, ok?",
+        "message":"Oh, sir. I'm not causing any trouble anymore, see? I sits outside now as you says, OK?",
         "replies":[
             {
                 "text":"N",
@@ -131,7 +131,7 @@
                 ]
             },
             {
-                "text":"Ok, I'll go buy some mead for you.",
+                "text":"OK, I'll go buy some mead for you.",
                 "nextPhraseID":"X"
             },
             {
@@ -163,7 +163,7 @@
                 ]
             },
             {
-                "text":"Ok, I'll go buy some mead for you.",
+                "text":"OK, I'll go buy some mead for you.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_larcal.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_larcal.json
@@ -56,7 +56,7 @@
     },
     {
         "id":"larcal_5",
-        "message":"Ok, now you're starting to annoy me, kid. Get lost while you still can.",
+        "message":"OK, now you're starting to annoy me, kid. Get lost while you still can.",
         "replies":[
             {
                 "text":"Very well. I will leave.",
@@ -70,7 +70,7 @@
     },
     {
         "id":"larcal_6",
-        "message":"You are still here? Ok then, if you want the book that bad, you will have to take it from me!",
+        "message":"You are still here? OK then, if you want the book that bad, you will have to take it from me!",
         "replies":[
             {
                 "text":"At last, a fight. I have been waiting for this!",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_nocmar.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_nocmar.json
@@ -143,7 +143,7 @@
     },
     {
         "id":"nocmar_quest_1",
-        "message":"Ok, these old weapons have lost their inner glow now that they haven't been used in a while.",
+        "message":"OK, these old weapons have lost their inner glow now that they haven't been used in a while.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_oldman.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_oldman.json
@@ -90,7 +90,7 @@
         "message":"I have no idea where it might be. You could go ask Arcir, he seems very fond of his books. *points at the house to the south*",
         "replies":[
             {
-                "text":"Ok, I'll go ask Arcir. Goodbye.",
+                "text":"OK, I'll go ask Arcir. Goodbye.",
                 "nextPhraseID":"X"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_vacor.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_vacor.json
@@ -250,7 +250,7 @@
     },
     {
         "id":"vacor_18",
-        "message":"Ok, find the four pieces of my rift spell that the bandits took, and bring the pieces to me.",
+        "message":"OK, find the four pieces of my rift spell that the bandits took, and bring the pieces to me.",
         "replies":[
             {
                 "text":"N",
@@ -607,7 +607,7 @@
                 "nextPhraseID":"vacor_72"
             },
             {
-                "text":"Ok, I'll think about it once more.",
+                "text":"OK, I'll think about it once more.",
                 "nextPhraseID":"X"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_warden.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_warden.json
@@ -111,7 +111,7 @@
                 ]
             },
             {
-                "text":"Ok, goodbye.",
+                "text":"OK, goodbye.",
                 "nextPhraseID":"X"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_farrik.json
+++ b/AndorsTrail/res/raw/conversationlist_farrik.json
@@ -215,7 +215,7 @@
     },
     {
         "id":"farrik_19",
-        "message":"Ok, here is the plan. The guard captain has a bit of a drinking problem.",
+        "message":"OK, here is the plan. The guard captain has a bit of a drinking problem.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_foamingflask_guards.json
+++ b/AndorsTrail/res/raw/conversationlist_foamingflask_guards.json
@@ -188,7 +188,7 @@
         "message":"I never talked to him though, so I don't know if he is the one you are looking for.",
         "replies":[
             {
-                "text":"Ok, that might be something worth checking anyway.",
+                "text":"OK, that might be something worth checking anyway.",
                 "nextPhraseID":"ff_captain_rincel_3"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_foamingflask_outsideguard.json
+++ b/AndorsTrail/res/raw/conversationlist_foamingflask_outsideguard.json
@@ -46,7 +46,7 @@
         "message":"Go talk to the captain inside if you want to talk. I must stay alert on my post.",
         "replies":[
             {
-                "text":"Ok. Goodbye.",
+                "text":"OK. Goodbye.",
                 "nextPhraseID":"X"
             },
             {
@@ -67,11 +67,11 @@
         "message":"Really, I cannot talk to you. I could get into trouble.",
         "replies":[
             {
-                "text":"Ok. I won't bother you anymore. Shadow be with you.",
+                "text":"OK. I won't bother you anymore. Shadow be with you.",
                 "nextPhraseID":"ff_outsideguard_shadow_1"
             },
             {
-                "text":"Ok. I won't bother you anymore. Goodbye.",
+                "text":"OK. I won't bother you anymore. Goodbye.",
                 "nextPhraseID":"X"
             },
             {
@@ -85,11 +85,11 @@
         "message":"No really, the captain might see me. I must be aware on my post at all times. *sigh*",
         "replies":[
             {
-                "text":"Ok. I won't bother you anymore. Shadow be with you.",
+                "text":"OK. I won't bother you anymore. Shadow be with you.",
                 "nextPhraseID":"ff_outsideguard_shadow_1"
             },
             {
-                "text":"Ok. I won't bother you anymore. Goodbye.",
+                "text":"OK. I won't bother you anymore. Goodbye.",
                 "nextPhraseID":"X"
             },
             {
@@ -100,7 +100,7 @@
     },
     {
         "id":"ff_outsideguard_trouble_3",
-        "message":"My job? I guess the royal guard is ok. I mean, Feygard is a really nice place to live in.",
+        "message":"My job? I guess the royal guard is OK. I mean, Feygard is a really nice place to live in.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_gandoren.json
+++ b/AndorsTrail/res/raw/conversationlist_gandoren.json
@@ -362,7 +362,7 @@
     },
     {
         "id":"gandoren_19",
-        "message":"Ok then.",
+        "message":"OK then.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_graveyard1.json
+++ b/AndorsTrail/res/raw/conversationlist_graveyard1.json
@@ -815,7 +815,7 @@
         "message":"There is a cave system that runs underneath the forest. If something sinister is afoot, it could be emanating from the ground below. Please, you must help me investigate the source of the monster invasion in this forest.",
         "replies":[
             {
-                "text":"Okay, I will help you.",
+                "text":"OK, I will help you.",
                 "nextPhraseID":"cithurn_50"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_hadracor.json
+++ b/AndorsTrail/res/raw/conversationlist_hadracor.json
@@ -96,7 +96,7 @@
         "message":"Looks like you eh? No, I would have remembered.",
         "replies":[
             {
-                "text":"Ok, goodbye.",
+                "text":"OK, goodbye.",
                 "nextPhraseID":"X"
             },
             {
@@ -436,7 +436,7 @@
                 "nextPhraseID":"X"
             },
             {
-                "text":"Ok, let me see what you have.",
+                "text":"OK, let me see what you have.",
                 "nextPhraseID":"S"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_highwayman1.json
+++ b/AndorsTrail/res/raw/conversationlist_highwayman1.json
@@ -93,7 +93,7 @@
         "message":"Oh no no, are you accusing me of robbing you? That's not the case at all. I'm just asking for 500 gold so that you won't be robbed of all your possessions while travelling down this road.",
         "replies":[
             {
-                "text":"Ok. Here is 500 gold.",
+                "text":"OK. Here is 500 gold.",
                 "nextPhraseID":"highwayman1_5",
                 "requires":[
                     {

--- a/AndorsTrail/res/raw/conversationlist_hjaldar.json
+++ b/AndorsTrail/res/raw/conversationlist_hjaldar.json
@@ -185,7 +185,7 @@
     },
     {
         "id":"hjaldar_11",
-        "message":"Ok then. Sorry I couldn't help you. Goodbye."
+        "message":"OK then. Sorry I couldn't help you. Goodbye."
     },
     {
         "id":"hjaldar_12",

--- a/AndorsTrail/res/raw/conversationlist_jan.json
+++ b/AndorsTrail/res/raw/conversationlist_jan.json
@@ -40,7 +40,7 @@
                 "nextPhraseID":"jan_default2"
             },
             {
-                "text":"Ok, bye.",
+                "text":"OK, bye.",
                 "nextPhraseID":"X"
             }
         ]
@@ -54,14 +54,14 @@
                 "nextPhraseID":"jan_default3"
             },
             {
-                "text":"Ok, bye.",
+                "text":"OK, bye.",
                 "nextPhraseID":"X"
             }
         ]
     },
     {
         "id":"jan_default3",
-        "message":"Well, I guess it's ok to tell you. You seem to be a nice enough kid.",
+        "message":"Well, I guess it's OK to tell you. You seem to be a nice enough kid.",
         "replies":[
             {
                 "text":"N",
@@ -207,7 +207,7 @@
         "message":"Return to me when you are done. Bring me Gandir's ring from Irogotu down in the cave.",
         "replies":[
             {
-                "text":"Ok, bye.",
+                "text":"OK, bye.",
                 "nextPhraseID":"X"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_jhaeld.json
+++ b/AndorsTrail/res/raw/conversationlist_jhaeld.json
@@ -177,7 +177,7 @@
                 "nextPhraseID":"jhaeld_7"
             },
             {
-                "text":"Sigh. Ok. I guess.",
+                "text":"Sigh. OK. I guess.",
                 "nextPhraseID":"jhaeld_7"
             },
             {
@@ -261,7 +261,7 @@
     },
     {
         "id":"jhaeld_10",
-        "message":"Ok, so what I would like you to do for me is ask some people what they know of the missing people. The fact that you are not from around here might help you get information that neither me nor my guards would be able to acquire.",
+        "message":"OK, so what I would like you to do for me is ask some people what they know of the missing people. The fact that you are not from around here might help you get information that neither me nor my guards would be able to acquire.",
         "replies":[
             {
                 "text":"Sounds simple enough.",

--- a/AndorsTrail/res/raw/conversationlist_jolnor.json
+++ b/AndorsTrail/res/raw/conversationlist_jolnor.json
@@ -251,7 +251,7 @@
         "message":"First, there is Kaori. She lives up in the northern part of Vilegard. Ask her if she wants help with anything.",
         "replies":[
             {
-                "text":"Ok. Talk to Kaori. Got it.",
+                "text":"OK. Talk to Kaori. Got it.",
                 "nextPhraseID":"jolnor_gaintrust_3"
             }
         ],
@@ -377,7 +377,7 @@
                 "nextPhraseID":"jolnor_gaintrust_14"
             },
             {
-                "text":"Ok, I hope this leads to some treasure in the end.",
+                "text":"OK, I hope this leads to some treasure in the end.",
                 "nextPhraseID":"jolnor_gaintrust_14"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_kantya.json
+++ b/AndorsTrail/res/raw/conversationlist_kantya.json
@@ -257,7 +257,7 @@
         "message":"You've helped us this far. Talk to Maevalia again, she might have something else for you.",
         "replies":[
             {
-                "text":"Ok, I'll go talk to Maevalia again.",
+                "text":"OK, I'll go talk to Maevalia again.",
                 "nextPhraseID":"kantya0"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_kaori.json
+++ b/AndorsTrail/res/raw/conversationlist_kaori.json
@@ -53,7 +53,7 @@
         "message":"I don't want to talk to you. Go talk to Jolnor in the chapel if you want to help us.",
         "replies":[
             {
-                "text":"Ok, bye.",
+                "text":"OK, bye.",
                 "nextPhraseID":"X"
             },
             {
@@ -170,7 +170,7 @@
         "message":"I would really like to have a few more of those. If you can bring me 10 bonemeal potions, I might consider trusting you a bit more.",
         "replies":[
             {
-                "text":"Ok. I will get some potions for you.",
+                "text":"OK. I will get some potions for you.",
                 "nextPhraseID":"kaori_14"
             },
             {
@@ -249,7 +249,7 @@
     },
     {
         "id":"kaori_21",
-        "message":"Yes, these will do fine. Thank you a lot kid. Maybe you are ok after all. May the Shadow watch over you.",
+        "message":"Yes, these will do fine. Thank you a lot kid. Maybe you are OK after all. May the Shadow watch over you.",
         "replies":[
             {
                 "text":"N",
@@ -276,7 +276,7 @@
         "message":"You should go talk to Erttu if you want the background story about Vilegard. She has been around here far longer than me.",
         "replies":[
             {
-                "text":"Ok, I will do that.",
+                "text":"OK, I will do that.",
                 "nextPhraseID":"kaori_default_1"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_kaverin.json
+++ b/AndorsTrail/res/raw/conversationlist_kaverin.json
@@ -169,7 +169,7 @@
     },
     {
         "id":"kaverin_5",
-        "message":"I guess he keeps to himself. I sure hope he is okay. If you ever run into him, please say hi to him for me.",
+        "message":"I guess he keeps to himself. I sure hope he is OK. If you ever run into him, please say hi to him for me.",
         "replies":[
             {
                 "text":"I'm trying to find my brother Andor, have you seen him?",

--- a/AndorsTrail/res/raw/conversationlist_lethenlor.json
+++ b/AndorsTrail/res/raw/conversationlist_lethenlor.json
@@ -41,7 +41,7 @@
     },
     {
         "id":"lethenlor3",
-        "message":"Ok. Good luck with that.",
+        "message":"OK. Good luck with that.",
         "replies":[
             {
                 "text":"Who are you?",

--- a/AndorsTrail/res/raw/conversationlist_lleglaris.json
+++ b/AndorsTrail/res/raw/conversationlist_lleglaris.json
@@ -310,7 +310,7 @@
     },
     {
         "id":"lleglaris_r2",
-        "message":"Ok then. I won't keep you."
+        "message":"OK then. I won't keep you."
     },
     {
         "id":"lleglaris_r3",

--- a/AndorsTrail/res/raw/conversationlist_lodar.json
+++ b/AndorsTrail/res/raw/conversationlist_lodar.json
@@ -178,7 +178,7 @@
                 "nextPhraseID":"lodar_7"
             },
             {
-                "text":"Ok then. I'll leave you to it. Good luck.",
+                "text":"OK then. I'll leave you to it. Good luck.",
                 "nextPhraseID":"X"
             }
         ]
@@ -327,7 +327,7 @@
                 "nextPhraseID":"lodar_13"
             },
             {
-                "text":"Ok. I'll be back once I'm done with your task.",
+                "text":"OK. I'll be back once I'm done with your task.",
                 "nextPhraseID":"lodar_13"
             }
         ]
@@ -2090,7 +2090,7 @@
                 "nextPhraseID":"X"
             },
             {
-                "text":"I hope it will be ok.",
+                "text":"I hope it will be OK.",
                 "nextPhraseID":"X"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_lodarfg.json
+++ b/AndorsTrail/res/raw/conversationlist_lodarfg.json
@@ -50,7 +50,7 @@
                 "nextPhraseID":"lodar_fg1_3"
             },
             {
-                "text":"Ok, I'll turn back. Thanks for the warning.",
+                "text":"OK, I'll turn back. Thanks for the warning.",
                 "nextPhraseID":"X"
             }
         ]
@@ -237,7 +237,7 @@
                 "nextPhraseID":"lodar_fg1_18"
             },
             {
-                "text":"Ok, I'll be on the look-out for any dangers.",
+                "text":"OK, I'll be on the look-out for any dangers.",
                 "nextPhraseID":"lodar_fg1_18"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_maevalia.json
+++ b/AndorsTrail/res/raw/conversationlist_maevalia.json
@@ -516,7 +516,7 @@
     },
     {
         "id":"maevalia24",
-        "message":"Ok. Frankly, I don't know what else we can do. We really need the help.",
+        "message":"OK. Frankly, I don't know what else we can do. We really need the help.",
         "replies":[
             {
                 "text":"N",
@@ -549,7 +549,7 @@
         "message":"Please, try to be safe! If you spot any danger, or if those foul monsters are too much for you, don't hesitate to retreat back here.",
         "replies":[
             {
-                "text":"Ok, I'll try to find your missing people.",
+                "text":"OK, I'll try to find your missing people.",
                 "nextPhraseID":"maevalia28"
             }
         ]
@@ -713,7 +713,7 @@
         "message":"I hear they are both anxious to talk to you now that they're safe. You should go meet them downstairs in the basement.",
         "replies":[
             {
-                "text":"Ok, I'll go see them in the basement.",
+                "text":"OK, I'll go see them in the basement.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_mikhail.json
+++ b/AndorsTrail/res/raw/conversationlist_mikhail.json
@@ -405,7 +405,7 @@
                 ]
             },
             {
-                "text":"Ok, I'll go check out in our garden.",
+                "text":"OK, I'll go check out in our garden.",
                 "nextPhraseID":"mikhail_rats_start2"
             }
         ],
@@ -432,7 +432,7 @@
         "message":"Also, don't forget to check your inventory. You probably still have that old ring I gave you. Make sure you wear it.",
         "replies":[
             {
-                "text":"Ok, I understand. I can rest here if I get hurt, and I should check my inventory for useful items.",
+                "text":"OK, I understand. I can rest here if I get hurt, and I should check my inventory for useful items.",
                 "nextPhraseID":"mikhail_default"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_ogam.json
+++ b/AndorsTrail/res/raw/conversationlist_ogam.json
@@ -140,7 +140,7 @@
         "message":"Lodar, halfway between the Shadow and the light. Rocky formations.",
         "replies":[
             {
-                "text":"Ok, halfway between two places. Some rocks?",
+                "text":"OK, halfway between two places. Some rocks?",
                 "nextPhraseID":"ogam_lodar_3"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_oluag.json
+++ b/AndorsTrail/res/raw/conversationlist_oluag.json
@@ -50,7 +50,7 @@
                 "nextPhraseID":"oluag_grave_select"
             },
             {
-                "text":"Ok then. I guess I didn't see anything.",
+                "text":"OK then. I guess I didn't see anything.",
                 "nextPhraseID":"oluag_goodbye"
             }
         ]
@@ -89,14 +89,14 @@
     },
     {
         "id":"oluag_grave_1",
-        "message":"Yeah, ok. So there is a grave right over there. I promise I had nothing to do with it.",
+        "message":"Yeah, OK. So there is a grave right over there. I promise I had nothing to do with it.",
         "replies":[
             {
                 "text":"Nothing? Really?",
                 "nextPhraseID":"oluag_grave_2"
             },
             {
-                "text":"Ok then. I guess you didn't have anything to do with it.",
+                "text":"OK then. I guess you didn't have anything to do with it.",
                 "nextPhraseID":"oluag_goodbye"
             }
         ]
@@ -113,7 +113,7 @@
     },
     {
         "id":"oluag_grave_3",
-        "message":"Ok, so maybe I just had a little bit to do with it.",
+        "message":"OK, so maybe I just had a little bit to do with it.",
         "replies":[
             {
                 "text":"You better start talking.",

--- a/AndorsTrail/res/raw/conversationlist_pathway_fallhaven.json
+++ b/AndorsTrail/res/raw/conversationlist_pathway_fallhaven.json
@@ -85,10 +85,10 @@
     },
     {
         "id":"guard_pathway_4",
-        "message":"Ok, maybe you can be of use. Talk to the warden. Maybe you can convince him to pay the woodcutter first. But I have to warn you, he is a stubborn beast.",
+        "message":"OK, maybe you can be of use. Talk to the warden. Maybe you can convince him to pay the woodcutter first. But I have to warn you, he is a stubborn beast.",
         "replies":[
             {
-                "text":"Okay thanks for your advice. I'm going to do that!",
+                "text":"OK, thanks for your advice. I'm going to do that!",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_prim_arghest.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_arghest.json
@@ -101,7 +101,7 @@
         "message":"No. The mine is closed.",
         "replies":[
             {
-                "text":"Ok, goodbye.",
+                "text":"OK, goodbye.",
                 "nextPhraseID":"X"
             },
             {
@@ -172,7 +172,7 @@
     },
     {
         "id":"arghest_return_3",
-        "message":"Ok then. Return to me once you have them.",
+        "message":"OK then. Return to me once you have them.",
         "replies":[
             {
                 "text":"Will do. Goodbye.",
@@ -305,7 +305,7 @@
                 "nextPhraseID":"X"
             },
             {
-                "text":"Ok. I'll be right back.",
+                "text":"OK. I'll be right back.",
                 "nextPhraseID":"X"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_prim_guthbered.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_guthbered.json
@@ -313,7 +313,7 @@
     },
     {
         "id":"guthbered_8",
-        "message":"Ok. We will have to investigate that later.",
+        "message":"OK. We will have to investigate that later.",
         "replies":[
             {
                 "text":"N",
@@ -602,7 +602,7 @@
         "message":"I want you to go up there to their settlement and ask their battle master, Harlenn, why they are doing this to us.",
         "replies":[
             {
-                "text":"Ok, I will go ask Harlenn in the Blackwater Mountain settlement why they are attacking your village.",
+                "text":"OK, I will go ask Harlenn in the Blackwater Mountain settlement why they are attacking your village.",
                 "nextPhraseID":"guthbered_31"
             }
         ],
@@ -777,7 +777,7 @@
         "message":"You should probably start your search around where their battle master, Harlenn, stays.",
         "replies":[
             {
-                "text":"Ok. I will look for clues in their settlement.",
+                "text":"OK. I will look for clues in their settlement.",
                 "nextPhraseID":"guthbered_talkedto_harl_13"
             }
         ]
@@ -1073,7 +1073,7 @@
     },
     {
         "id":"guthbered_sentbybwm_7",
-        "message":"Ok, you have convinced me. I will leave Prim for another town. The survival of my people here is more important than me.",
+        "message":"OK, you have convinced me. I will leave Prim for another town. The survival of my people here is more important than me.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_prim_inn.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_inn.json
@@ -228,7 +228,7 @@
         "message":"Now that you mention it, he hasn't been around here for quite some time. Maybe you could go talk to him and see if he still wants to rent it?",
         "replies":[
             {
-                "text":"Ok, I will go talk to him.",
+                "text":"OK, I will go talk to him.",
                 "nextPhraseID":"prim_cook_7"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_prim_merchants.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_merchants.json
@@ -42,7 +42,7 @@
         "message":"I must tell you that my supply is not what it used to be, now that the southern mine entrance has collapsed. Far fewer traders come here to Prim now.",
         "replies":[
             {
-                "text":"Ok, let me see your wares.",
+                "text":"OK, let me see your wares.",
                 "nextPhraseID":"S"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_prim_outside.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_outside.json
@@ -122,7 +122,7 @@
         "message":"You should speak to Guthbered, in the Prim main hall, just north of here.",
         "replies":[
             {
-                "text":"Ok, I will go see him.",
+                "text":"OK, I will go see him.",
                 "nextPhraseID":"tonis_8"
             },
             {
@@ -147,7 +147,7 @@
         "message":"The village of Prim is just north of here. You can probably see it through the trees over there.",
         "replies":[
             {
-                "text":"Ok, I will go there right away.",
+                "text":"OK, I will go there right away.",
                 "nextPhraseID":"tonis_8"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_prim_tavern.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_tavern.json
@@ -42,7 +42,7 @@
         "message":"Suit yourself. That's what I've got anyway.",
         "replies":[
             {
-                "text":"Ok, let's trade anyway.",
+                "text":"OK, let's trade anyway.",
                 "nextPhraseID":"S"
             },
             {
@@ -102,7 +102,7 @@
                 "nextPhraseID":"X"
             },
             {
-                "text":"Ok.",
+                "text":"OK.",
                 "nextPhraseID":"X"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_pwcave.json
+++ b/AndorsTrail/res/raw/conversationlist_pwcave.json
@@ -133,7 +133,7 @@
         "message":"Tell you what though. Bring me those claws of theirs, and I'll buy them from you for a good price.",
         "replies":[
             {
-                "text":"Ok, I will return with some of their claws.",
+                "text":"OK, I will return with some of their claws.",
                 "nextPhraseID":"gauward_7"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_reinkarr.json
+++ b/AndorsTrail/res/raw/conversationlist_reinkarr.json
@@ -19,7 +19,7 @@
     },
     {
         "id":"reinkarr_1",
-        "message":"Ok then. Good luck with that.",
+        "message":"OK then. Good luck with that.",
         "replies":[
             {
                 "text":"Who are you?",

--- a/AndorsTrail/res/raw/conversationlist_remgard_bridgeguard.json
+++ b/AndorsTrail/res/raw/conversationlist_remgard_bridgeguard.json
@@ -117,7 +117,7 @@
                 "nextPhraseID":"remgardb_help_1"
             },
             {
-                "text":"Ok, I will leave you to your investigation.",
+                "text":"OK, I will leave you to your investigation.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_remgard_villagers1.json
+++ b/AndorsTrail/res/raw/conversationlist_remgard_villagers1.json
@@ -11,7 +11,7 @@
     },
     {
         "id":"remgard_villager1_2",
-        "message":"Ok then. Good luck with that."
+        "message":"OK then. Good luck with that."
     },
     {
         "id":"remgard_villager2",

--- a/AndorsTrail/res/raw/conversationlist_rothses.json
+++ b/AndorsTrail/res/raw/conversationlist_rothses.json
@@ -87,7 +87,7 @@
     },
     {
         "id":"rothses_2",
-        "message":"It's ok, I guess. Not as good as I would like it to be, now that the gates to the town are closed. But people here still seem to need new pieces of leather every now and then.",
+        "message":"It's OK, I guess. Not as good as I would like it to be, now that the gates to the town are closed. But people here still seem to need new pieces of leather every now and then.",
         "replies":[
             {
                 "text":"Let me see what you have for sale.",

--- a/AndorsTrail/res/raw/conversationlist_stoutford.json
+++ b/AndorsTrail/res/raw/conversationlist_stoutford.json
@@ -882,7 +882,7 @@
     },
     {
         "id":"glasforn_rumblings20_2",
-        "message":"Okay, I can believe that you are Andor's brother. You should have told me earlier!",
+        "message":"OK, I can believe that you are Andor's brother. You should have told me earlier!",
         "replies":[
             {
                 "text":"Why?",
@@ -1546,7 +1546,7 @@
         "message":"First, I need two coins. Please give me 2 gold coins.",
         "replies":[
             {
-                "text":"Ok.",
+                "text":"OK.",
                 "nextPhraseID":"tahalendor_erwyn_5",
                 "requires":[
                     {

--- a/AndorsTrail/res/raw/conversationlist_stoutford_combined.json
+++ b/AndorsTrail/res/raw/conversationlist_stoutford_combined.json
@@ -3143,7 +3143,7 @@
                 "nextPhraseID":"odirath_1"
             },
             {
-                "text":"Ok. Can you tell me anything about Stoutford?",
+                "text":"OK. Can you tell me anything about Stoutford?",
                 "nextPhraseID":"odirath_1_1"
             },
             {
@@ -6652,7 +6652,7 @@
         "switchToNPC":"stn_gyra1",
         "replies":[
             {
-                "text":"Sigh. Ok.",
+                "text":"Sigh. OK.",
                 "nextPhraseID":"X"
             }
         ]
@@ -10319,7 +10319,7 @@
         "switchToNPC":"stn_colonel",
         "replies":[
             {
-                "text":"Ok, let's begin.",
+                "text":"OK, let's begin.",
                 "nextPhraseID":"stn_colonel_111"
             }
         ]
@@ -10427,7 +10427,7 @@
         "switchToNPC":"stn_colonel",
         "replies":[
             {
-                "text":"Ok.",
+                "text":"OK.",
                 "nextPhraseID":"stn_colonel_130"
             }
         ],

--- a/AndorsTrail/res/raw/conversationlist_talion_2.json
+++ b/AndorsTrail/res/raw/conversationlist_talion_2.json
@@ -97,7 +97,7 @@
         "message":"Then you better go take care of that first!",
         "replies":[
             {
-                "text":"Ok, I will be back once the lich is defeated.",
+                "text":"OK, I will be back once the lich is defeated.",
                 "nextPhraseID":"X"
             }
         ]
@@ -217,7 +217,7 @@
         "message":"Now, I have not seen an Irdegh myself, but I hear they are particularly nasty creatures. Venomous like nothing I've heard of.",
         "replies":[
             {
-                "text":"Ok, one Irdegh poison gland. Where can I find one?",
+                "text":"OK, one Irdegh poison gland. Where can I find one?",
                 "nextPhraseID":"talion_infect_17"
             },
             {
@@ -774,7 +774,7 @@
                 "nextPhraseID":"talion_cured_4"
             },
             {
-                "text":"Ok, I will hold on to it.",
+                "text":"OK, I will hold on to it.",
                 "nextPhraseID":"talion_cured_7"
             },
             {
@@ -881,7 +881,7 @@
         "message":"The blessing of Shadow strength grants you more strength while attacking, thus increasing the amount of damage you do on each hit. I can give you the blessing for 300 gold.",
         "replies":[
             {
-                "text":"Ok, I'll take it for 300 gold.",
+                "text":"OK, I'll take it for 300 gold.",
                 "nextPhraseID":"talion_bless_str_2",
                 "requires":[
                     {
@@ -902,7 +902,7 @@
         "message":"The blessing of Shadow regeneration will slowly heal you back if you get hurt. I can give you the blessing for 250 gold.",
         "replies":[
             {
-                "text":"Ok, I'll take it for 250 gold.",
+                "text":"OK, I'll take it for 250 gold.",
                 "nextPhraseID":"talion_bless_heal_2",
                 "requires":[
                     {
@@ -923,7 +923,7 @@
         "message":"The blessing of Shadow accuracy grants you a keen sense of where best to strike your opponent, thus increasing the chance of a successful hit while fighting. I can give you the blessing for 250 gold.",
         "replies":[
             {
-                "text":"Ok, I'll take it for 250 gold.",
+                "text":"OK, I'll take it for 250 gold.",
                 "nextPhraseID":"talion_bless_acc_2",
                 "requires":[
                     {
@@ -944,7 +944,7 @@
         "message":"Ah yes, the blessing of the Shadow guardian. The Shadow protects you in dark places, and keeps you safe where others might not see. I can give you the blessing for 400 gold.",
         "replies":[
             {
-                "text":"Ok, I'll take it for 400 gold.",
+                "text":"OK, I'll take it for 400 gold.",
                 "nextPhraseID":"talion_bless_guard_2",
                 "requires":[
                     {

--- a/AndorsTrail/res/raw/conversationlist_thievesguild_1.json
+++ b/AndorsTrail/res/raw/conversationlist_thievesguild_1.json
@@ -338,7 +338,7 @@
         "message":"No. I don't know. I just manage the supplies.",
         "replies":[
             {
-                "text":"Ok, thanks anyway. Goodbye.",
+                "text":"OK, thanks anyway. Goodbye.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_thorin.json
+++ b/AndorsTrail/res/raw/conversationlist_thorin.json
@@ -255,7 +255,7 @@
     },
     {
         "id":"thorin_search_2",
-        "message":"Ok then. Please return when you have found them all. I would go search myself if those nasty bugs weren't there."
+        "message":"OK then. Please return when you have found them all. I would go search myself if those nasty bugs weren't there."
     },
     {
         "id":"thorin_rest_1",

--- a/AndorsTrail/res/raw/conversationlist_tiqui.json
+++ b/AndorsTrail/res/raw/conversationlist_tiqui.json
@@ -307,7 +307,7 @@
                 "nextPhraseID":"tiqui_atk"
             },
             {
-                "text":"Ok. I will help you.",
+                "text":"OK. I will help you.",
                 "nextPhraseID":"tiqui15"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_twoteeth.json
+++ b/AndorsTrail/res/raw/conversationlist_twoteeth.json
@@ -89,7 +89,7 @@
     },
     {
         "id":"twoteeth_5",
-        "message":"Ok, ok! No need to get all violent.",
+        "message":"OK, OK! No need to get all violent.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_ulirfendor.json
+++ b/AndorsTrail/res/raw/conversationlist_ulirfendor.json
@@ -894,7 +894,7 @@
         "message":"Seek him out immediately. Hurry! You might not have much time.",
         "replies":[
             {
-                "text":"Ok, I will go to Talion in the Loneford temple at once. Goodbye.",
+                "text":"OK, I will go to Talion in the Loneford temple at once. Goodbye.",
                 "nextPhraseID":"X"
             }
         ]
@@ -904,7 +904,7 @@
         "message":"I should also tell you that it is of great importance that you first destroy whatever creature that infected you with this.",
         "replies":[
             {
-                "text":"Ok, I will defeat the lich first. Goodbye.",
+                "text":"OK, I will defeat the lich first. Goodbye.",
                 "nextPhraseID":"X"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_umar.json
+++ b/AndorsTrail/res/raw/conversationlist_umar.json
@@ -273,10 +273,10 @@
     },
     {
         "id":"umar_lodar_3",
-        "message":"Ok, I'll tell you how to get to Lodar's Hideaway. But you have to promise to keep it a secret. Do not tell anyone. Not even those that appear to be members of the Thieves' Guild.",
+        "message":"OK, I'll tell you how to get to Lodar's Hideaway. But you have to promise to keep it a secret. Do not tell anyone. Not even those that appear to be members of the Thieves' Guild.",
         "replies":[
             {
-                "text":"Ok, I'll promise to keep it a secret.",
+                "text":"OK, I'll promise to keep it a secret.",
                 "nextPhraseID":"umar_lodar_4"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_vilegard_v070.json
+++ b/AndorsTrail/res/raw/conversationlist_vilegard_v070.json
@@ -237,7 +237,7 @@
     },
     {
         "id":"vilegard_smith_xul_19",
-        "message":"Sigh. Ok, whatever you say. We just need to fit these into there, and sharpen up this bit here.\nThere. It should be almost like it once was.",
+        "message":"Sigh. OK, whatever you say. We just need to fit these into there, and sharpen up this bit here.\nThere. It should be almost like it once was.",
         "replies":[
             {
                 "text":"Thanks.",

--- a/AndorsTrail/res/raw/conversationlist_wrye.json
+++ b/AndorsTrail/res/raw/conversationlist_wrye.json
@@ -311,7 +311,7 @@
         "message":"No, but I know it in me that they are. The Shadow speaks to me.",
         "replies":[
             {
-                "text":"Ok. Is there anything I can do to help?",
+                "text":"OK. Is there anything I can do to help?",
                 "nextPhraseID":"wrye_story_13"
             },
             {
@@ -333,7 +333,7 @@
                 "nextPhraseID":"wrye_story_16"
             },
             {
-                "text":"Ok. I will go look for your son. I sure hope there will be some reward for this.",
+                "text":"OK. I will go look for your son. I sure hope there will be some reward for this.",
                 "nextPhraseID":"wrye_story_14"
             },
             {
@@ -372,11 +372,11 @@
                 "nextPhraseID":"wrye_story_14"
             },
             {
-                "text":"Ok. I will go look for your son. I sure hope there will be some reward for this.",
+                "text":"OK. I will go look for your son. I sure hope there will be some reward for this.",
                 "nextPhraseID":"wrye_story_14"
             },
             {
-                "text":"Ok. I will go look for your son so that you may know what happened to him.",
+                "text":"OK. I will go look for your son so that you may know what happened to him.",
                 "nextPhraseID":"wrye_story_14"
             }
         ],

--- a/AndorsTrail/res/raw/questlist_guynmart.json
+++ b/AndorsTrail/res/raw/questlist_guynmart.json
@@ -593,7 +593,7 @@
             },
             {
                 "progress":3,
-                "logText":"3=Dungeonhole ok"
+                "logText":"3=Dungeonhole OK"
             },
             {
                 "progress":4,


### PR DESCRIPTION
Hello @Zukero 
I fixed spelling of "OK", as I discussed with @Rijackson.
Done with the following commands:
```
sed -i 's/Okay/OK/g' AndorsTrail/res/raw/*.json
sed -i 's/Ok/OK/g' AndorsTrail/res/raw/*.json
```
