### PR TITLE
Fixed spelling of Hmm

### DIFF
--- a/AndorsTrail/res/raw/conversationlist_arghes.json
+++ b/AndorsTrail/res/raw/conversationlist_arghes.json
@@ -41,7 +41,7 @@
     },
     {
         "id":"arghes_3a",
-        "message":"Is that so? Hm, most interesting. It does not change anything, however.",
+        "message":"Is that so? Hmm, most interesting. It does not change anything, however.",
         "replies":[
             {
                 "text":"N",
@@ -115,7 +115,7 @@
     },
     {
         "id":"arghes_7",
-        "message":"Hm, let me see.",
+        "message":"Hmm, let me see.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_blackwater_harlenn.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_harlenn.json
@@ -1025,7 +1025,7 @@
     },
     {
         "id":"harlenn_sentbyprim_6",
-        "message":"Hm, you might have a point there.",
+        "message":"Hmm, you might have a point there.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_blackwater_throdna.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_throdna.json
@@ -243,7 +243,7 @@
     },
     {
         "id":"throdna_16",
-        "message":"Hm, maybe you could be of use here..",
+        "message":"Hmm, maybe you could be of use here..",
         "replies":[
             {
                 "text":"I would be glad to help.",

--- a/AndorsTrail/res/raw/conversationlist_buceth.json
+++ b/AndorsTrail/res/raw/conversationlist_buceth.json
@@ -138,7 +138,7 @@
     },
     {
         "id":"buceth_gold_1",
-        "message":"Hm, that might be an interesting proposal. How much gold are you suggesting?",
+        "message":"Hmm, that might be an interesting proposal. How much gold are you suggesting?",
         "replies":[
             {
                 "text":"Here's 10 gold, take it.",

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_1.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_1.json
@@ -67,14 +67,14 @@
                 "nextPhraseID":"bwm_agent_1_6"
             },
             {
-                "text":"Hm, no. I had better not get involved in this.",
+                "text":"Hmm, no. I had better not get involved in this.",
                 "nextPhraseID":"X"
             }
         ]
     },
     {
         "id":"bwm_agent_1_6",
-        "message":"Reward? Hm, I was hoping you would help us for other reasons than a reward. But I guess my master will reward you sufficiently if you survive.",
+        "message":"Reward? Hmm, I was hoping you would help us for other reasons than a reward. But I guess my master will reward you sufficiently if you survive.",
         "replies":[
             {
                 "text":"Alright, I'll do it.",

--- a/AndorsTrail/res/raw/conversationlist_crossroads_3.json
+++ b/AndorsTrail/res/raw/conversationlist_crossroads_3.json
@@ -132,7 +132,7 @@
     },
     {
         "id":"crossroads_backguard_4",
-        "message":"You would do that? Hm, let me think.",
+        "message":"You would do that? Hmm, let me think.",
         "replies":[
             {
                 "text":"N",
@@ -184,7 +184,7 @@
     },
     {
         "id":"crossroads_backguard_8",
-        "message":"Hm, 800 gold you say? Well, why didn't you say so from the start? Sure, that could work.",
+        "message":"Hmm, 800 gold you say? Well, why didn't you say so from the start? Sure, that could work.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_debug.json
+++ b/AndorsTrail/res/raw/conversationlist_debug.json
@@ -183,7 +183,7 @@
     "message": "Sorry. You already spent 100 gold..."
   },
   {
-        "message":"Hmmm.... Beer....",
+        "message":"Hmm.... Beer....",
         "id":"signbeer"
     },
     {

--- a/AndorsTrail/res/raw/conversationlist_elwyl.json
+++ b/AndorsTrail/res/raw/conversationlist_elwyl.json
@@ -455,7 +455,7 @@
     },
     {
         "id":"elwyl_res_3",
-        "message":"Hm, yes, it smells exactly as I remember it. It must be the right potion.",
+        "message":"Hmm, yes, it smells exactly as I remember it. It must be the right potion.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_erinith.json
+++ b/AndorsTrail/res/raw/conversationlist_erinith.json
@@ -436,7 +436,7 @@
     },
     {
         "id":"erinith_gavepotion_bm_2",
-        "message":"Hm, yes. I guess you have a point. Oh well, here goes. *drinks potion*",
+        "message":"Hmm, yes. I guess you have a point. Oh well, here goes. *drinks potion*",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven.json
@@ -59,7 +59,7 @@
     },
     {
         "id":"fallhaven_andor_2",
-        "message":"Some other kid you say? Hm, let me think.",
+        "message":"Some other kid you say? Hmm, let me think.",
         "replies":[
             {
                 "text":"N",
@@ -69,7 +69,7 @@
     },
     {
         "id":"fallhaven_andor_3",
-        "message":"Hm, I might have seen someone matching that description a few days ago. Can't remember where though."
+        "message":"Hmm, I might have seen someone matching that description a few days ago. Can't remember where though."
     },
     {
         "id":"fallhaven_andor_4",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_arcir.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_arcir.json
@@ -74,7 +74,7 @@
     },
     {
         "id":"arcir_calomyran_1",
-        "message":"'Calomyran Secrets'? Hm, yes I think I have one of those in my basement.",
+        "message":"'Calomyran Secrets'? Hmm, yes I think I have one of those in my basement.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_athamyr.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_athamyr.json
@@ -38,7 +38,7 @@
     },
     {
         "id":"athamyr_3",
-        "message":"You want to go down in the catacombs? Hm, maybe we can make a deal.",
+        "message":"You want to go down in the catacombs? Hmm, maybe we can make a deal.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_south.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_south.json
@@ -94,7 +94,7 @@
     },
     {
         "id":"alaun_2",
-        "message":"You are looking for your brother you say? Looks like you? Hm.",
+        "message":"You are looking for your brother you say? Looks like you? Hmm.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_vacor.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_vacor.json
@@ -67,7 +67,7 @@
     },
     {
         "id":"vacor_2",
-        "message":"What are you, some kind of adventurer? Hm. Maybe you can be of use to me.",
+        "message":"What are you, some kind of adventurer? Hmm. Maybe you can be of use to me.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_graveyard1.json
+++ b/AndorsTrail/res/raw/conversationlist_graveyard1.json
@@ -967,7 +967,7 @@
     },
     {
         "id":"cithurn_70",
-        "message":"Hmmm... I'll work on the parts that aren't dangerous. A brave and expert fighter like yourself is better suited to the dangerous parts.",
+        "message":"Hmm... I'll work on the parts that aren't dangerous. A brave and expert fighter like yourself is better suited to the dangerous parts.",
         "replies":[
             {
                 "text":"Danger is my middle name! I'll help you.",

--- a/AndorsTrail/res/raw/conversationlist_guynmart2_npc.json
+++ b/AndorsTrail/res/raw/conversationlist_guynmart2_npc.json
@@ -66,7 +66,7 @@
                 "nextPhraseID":"F"
             },
             {
-                "text":"Hm, I will think about your offer.",
+                "text":"Hmm, I will think about your offer.",
                 "nextPhraseID":"X"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_jan.json
+++ b/AndorsTrail/res/raw/conversationlist_jan.json
@@ -169,7 +169,7 @@
     },
     {
         "id":"jan_default12",
-        "message":"Really? You think you could help? Hm, maybe you could. Beware of those bugs though, they're really tough bastards.",
+        "message":"Really? You think you could help? Hmm, maybe you could. Beware of those bugs though, they're really tough bastards.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_jhaeld.json
+++ b/AndorsTrail/res/raw/conversationlist_jhaeld.json
@@ -170,7 +170,7 @@
     },
     {
         "id":"jhaeld_4",
-        "message":"Hm, now that you are here you might as well make yourself useful instead of just standing there looking stupid. Even if you are a kid, you might be able to gather some information for me.",
+        "message":"Hmm, now that you are here you might as well make yourself useful instead of just standing there looking stupid. Even if you are a kid, you might be able to gather some information for me.",
         "replies":[
             {
                 "text":"Sure, what do you need help with?",
@@ -750,7 +750,7 @@
     },
     {
         "id":"jhaeld_alg_1",
-        "message":"Hm, yes, and what of it?",
+        "message":"Hmm, yes, and what of it?",
         "replies":[
             {
                 "text":"I met a woman named Algangror in that house.",

--- a/AndorsTrail/res/raw/conversationlist_kaori.json
+++ b/AndorsTrail/res/raw/conversationlist_kaori.json
@@ -99,7 +99,7 @@
     },
     {
         "id":"kaori_5",
-        "message":"Hm. Maybe not. But then again, maybe you are. I am still not sure.",
+        "message":"Hmm. Maybe not. But then again, maybe you are. I am still not sure.",
         "replies":[
             {
                 "text":"Is there anything I can do to gain your trust?",

--- a/AndorsTrail/res/raw/conversationlist_lodar.json
+++ b/AndorsTrail/res/raw/conversationlist_lodar.json
@@ -232,7 +232,7 @@
     },
     {
         "id":"lodar_11",
-        "message":"No.. Hm, wait. You! Maybe you can be of use here, if you are willing to help?",
+        "message":"No.. Hmm, wait. You! Maybe you can be of use here, if you are willing to help?",
         "replies":[
             {
                 "text":"I'm up for it! What do you need help with?",
@@ -1505,7 +1505,7 @@
     },
     {
         "id":"lodar_hira9",
-        "message":"Formations of rocks you say? Hm. I don't recall seeing any of that the last time I ventured out.",
+        "message":"Formations of rocks you say? Hmm. I don't recall seeing any of that the last time I ventured out.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_loneford_kuldan.json
+++ b/AndorsTrail/res/raw/conversationlist_loneford_kuldan.json
@@ -110,7 +110,7 @@
     },
     {
         "id":"kuldan_bc_4",
-        "message":"Dead you say? Hm, not quite the way we do things in Feygard, but I guess this is an exceptional case.",
+        "message":"Dead you say? Hmm, not quite the way we do things in Feygard, but I guess this is an exceptional case.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_prim_guthbered.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_guthbered.json
@@ -691,7 +691,7 @@
                 "nextPhraseID":"guthbered_talkedto_harl_8"
             },
             {
-                "text":"Hm, maybe I should help the people up in Blackwater Mountain instead.",
+                "text":"Hmm, maybe I should help the people up in Blackwater Mountain instead.",
                 "nextPhraseID":"guthbered_workingforbwm_1"
             },
             {
@@ -1063,7 +1063,7 @@
     },
     {
         "id":"guthbered_sentbybwm_6",
-        "message":"Hm, you might have a point there.",
+        "message":"Hmm, you might have a point there.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_prim_inn.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_inn.json
@@ -215,7 +215,7 @@
     },
     {
         "id":"prim_cook_3",
-        "message":"Rent? Hm. No, not at the moment.",
+        "message":"Rent? Hmm. No, not at the moment.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_remgard_bridgeguard.json
+++ b/AndorsTrail/res/raw/conversationlist_remgard_bridgeguard.json
@@ -132,7 +132,7 @@
     },
     {
         "id":"remgardb_help_1",
-        "message":"Hm, yes, that might be a good idea actually. Considering you made it up here, you must have some knowledge of the surroundings.",
+        "message":"Hmm, yes, that might be a good idea actually. Considering you made it up here, you must have some knowledge of the surroundings.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_rothses.json
+++ b/AndorsTrail/res/raw/conversationlist_rothses.json
@@ -294,7 +294,7 @@
     },
     {
         "id":"rothses_imp_s0",
-        "message":"Hm, let me see.",
+        "message":"Hmm, let me see.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_stoutford_combined.json
+++ b/AndorsTrail/res/raw/conversationlist_stoutford_combined.json
@@ -2488,7 +2488,7 @@
     },
     {
         "id":"blornvale_s1_5",
-        "message":"Hm, yes. How could you prove it? Let me think ...",
+        "message":"Hmm, yes. How could you prove it? Let me think ...",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_thorin.json
+++ b/AndorsTrail/res/raw/conversationlist_thorin.json
@@ -194,7 +194,7 @@
                 "nextPhraseID":"thorin_story_11"
             },
             {
-                "text":"Hm, this sounds a bit shady to me. I'm not sure I should do this.",
+                "text":"Hmm, this sounds a bit shady to me. I'm not sure I should do this.",
                 "nextPhraseID":"thorin_decline"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_ulirfendor.json
+++ b/AndorsTrail/res/raw/conversationlist_ulirfendor.json
@@ -376,7 +376,7 @@
     },
     {
         "id":"ulirfendor_18",
-        "message":"Hm, maybe. I need to figure out what this last part should be. Hmm..",
+        "message":"Hmm, maybe. I need to figure out what this last part should be. Hmm..",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_unzel2.json
+++ b/AndorsTrail/res/raw/conversationlist_unzel2.json
@@ -18,7 +18,7 @@
     },
     {
         "id":"unzel_msg2",
-        "message":"Hmmm, yes... Let's see... (Unzel opens the sealed message and reads it)",
+        "message":"Hmm, yes... Let's see... (Unzel opens the sealed message and reads it)",
         "replies":[
             {
                 "text":"N",


### PR DESCRIPTION
> Just checked my list. We also have both "Hm", and "Hmm". The latter is correct. Fixing this might be a little harder, because of course every "Hmm" contains "Hm".

Hello @Rijackson
Hmm, it was quite simple, because each "Hm" was followed by a dot or a comma, so I only changed the following:
```
sed -i 's/Hm\./Hmm./g' AndorsTrail/res/raw/*.json
sed -i 's/Hm,/Hmm,/g' AndorsTrail/res/raw/*.json
sed -i 's/Hmmm/Hmm/g' AndorsTrail/res/raw/*.json
```

Now your list is shorter with one item. Please create separate [issues](https://github.com/Zukero/andors-trail/issues) for each to-do list items, and I try to solve everything. It is for me like a quest in AT: _I sure hope there will be some reward for this._ :)