### PR TITLE
Fixed spelling of Blackwater mountain settlement

### DIFF
--- a/AndorsTrail/res/raw/conversationlist_blackwater_harlenn.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_harlenn.json
@@ -629,7 +629,7 @@
     },
     {
         "id":"harlenn_completed",
-        "message":"Thank you, friend. Your help is greatly appreciated. Everyone in the Blackwater Mountain settlement will want to talk to you now.",
+        "message":"Thank you, friend. Your help is greatly appreciated. Everyone in the Blackwater mountain settlement will want to talk to you now.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_blackwater_lower.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_lower.json
@@ -40,7 +40,7 @@
     },
     {
         "id":"laede_3",
-        "message":"Welcome traveller. These beds are only for residents of Blackwater Mountain."
+        "message":"Welcome traveller. These beds are only for residents of Blackwater mountain."
     },
     {
         "id":"iducus",
@@ -214,7 +214,7 @@
     },
     {
         "id":"blackwater_throneguard_1",
-        "message":"Only residents of Blackwater Mountain or faction members are allowed in here.",
+        "message":"Only residents of Blackwater mountain or faction members are allowed in here.",
         "replies":[
             {
                 "text":"Here, I have a written permit to enter.",

--- a/AndorsTrail/res/raw/conversationlist_blackwater_signs.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_signs.json
@@ -9,7 +9,7 @@
     },
     {
         "id":"sign_blackwater0",
-        "message":"East: Fallhaven\nSouthwest: Stoutford\nNorthwest: Blackwater Mountain"
+        "message":"East: Fallhaven\nSouthwest: Stoutford\nNorthwest: Blackwater mountain"
     },
     {
         "id":"sign_prim_n",
@@ -198,7 +198,7 @@
     },
     {
         "id":"sign_blackwater50_right",
-        "message":"This leads back into the Blackwater Mountain settlement."
+        "message":"This leads back into the Blackwater mountain settlement."
     },
     {
         "id":"sign_blackwater29",
@@ -234,7 +234,7 @@
     },
     {
         "id":"sign_blackwater29_qstarted_1",
-        "message":"Among the papers, you find plans for recruiting mercenaries for Prim and training fighters for a larger attack on the Blackwater Mountain settlement.",
+        "message":"Among the papers, you find plans for recruiting mercenaries for Prim and training fighters for a larger attack on the Blackwater mountain settlement.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_blackwater_throdna.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_throdna.json
@@ -121,7 +121,7 @@
     },
     {
         "id":"throdna_6",
-        "message":"This is the mages' chamber in Blackwater Mountain. We devote our time to the studies of the Shadow and its descendants.",
+        "message":"This is the mages' chamber in Blackwater mountain. We devote our time to the studies of the Shadow and its descendants.",
         "replies":[
             {
                 "text":"Descendants?",
@@ -275,7 +275,7 @@
     },
     {
         "id":"throdna_19",
-        "message":"OK. Find me the pieces of the ritual that the former messenger carried on him. They should be found somewhere on the path up to Blackwater Mountain.",
+        "message":"OK. Find me the pieces of the ritual that the former messenger carried on him. They should be found somewhere on the path up to Blackwater mountain.",
         "replies":[
             {
                 "text":"I will return with your parts of the ritual.",
@@ -501,7 +501,7 @@
     },
     {
         "id":"throdna_return_8",
-        "message":"We need you to do two things. First, you must find the shrine of Kazaul. Our scouts tell us that the shrine should be located somewhere near the base of Blackwater Mountain.",
+        "message":"We need you to do two things. First, you must find the shrine of Kazaul. Our scouts tell us that the shrine should be located somewhere near the base of Blackwater mountain.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_blackwater_upper.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_upper.json
@@ -61,7 +61,7 @@
     },
     {
         "id":"blackwater_notrust",
-        "message":"Regardless, I cannot help you. My services are only for residents of Blackwater Mountain, and I don't trust you enough yet."
+        "message":"Regardless, I cannot help you. My services are only for residents of Blackwater mountain, and I don't trust you enough yet."
     },
     {
         "id":"waeges",

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_1.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_1.json
@@ -84,7 +84,7 @@
     },
     {
         "id":"bwm_agent_1_7",
-        "message":"Excellent. The Blackwater settlement is some distance away. Frankly, I am amazed that I made it this far alive.",
+        "message":"Excellent. The Blackwater mountain settlement is some distance away. Frankly, I am amazed that I made it this far alive.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_hjaldar.json
+++ b/AndorsTrail/res/raw/conversationlist_hjaldar.json
@@ -290,18 +290,18 @@
         "message":"Tell me, did you find Mazeg or did you get it from somewhere else?",
         "replies":[
             {
-                "text":"I visited Mazeg up in the Blackwater Mountain settlement.",
+                "text":"I visited Mazeg up in the Blackwater mountain settlement.",
                 "nextPhraseID":"hjaldar_r5"
             },
             {
-                "text":"You made me run all the way to Blackwater Mountain, I sure hope those potions are worth it!",
+                "text":"You made me run all the way to Blackwater mountain, I sure hope those potions are worth it!",
                 "nextPhraseID":"hjaldar_r5"
             }
         ]
     },
     {
         "id":"hjaldar_r5",
-        "message":"Blackwater Mountain? I'm afraid I don't know where that is. Never mind, I hope that all is well with my old friend.",
+        "message":"Blackwater mountain? I'm afraid I don't know where that is. Never mind, I hope that all is well with my old friend.",
         "replies":[
             {
                 "text":"He told me to send you his warmest greetings.",

--- a/AndorsTrail/res/raw/conversationlist_lleglaris.json
+++ b/AndorsTrail/res/raw/conversationlist_lleglaris.json
@@ -122,7 +122,7 @@
                 ]
             },
             {
-                "text":"I saved the settlement of Prim from the attacks from Blackwater Mountain.",
+                "text":"I saved the settlement of Prim from the attacks from Blackwater mountain.",
                 "nextPhraseID":"lleglaris3",
                 "requires":[
                     {
@@ -133,7 +133,7 @@
                 ]
             },
             {
-                "text":"I helped the Blackwater Mountain settlement make the attacks from Prim stop.",
+                "text":"I helped the Blackwater mountain settlement make the attacks from Prim stop.",
                 "nextPhraseID":"lleglaris3",
                 "requires":[
                     {

--- a/AndorsTrail/res/raw/conversationlist_mazeg.json
+++ b/AndorsTrail/res/raw/conversationlist_mazeg.json
@@ -175,7 +175,7 @@
     },
     {
         "id":"mazeg_e_7a",
-        "message":"Since you helped us up here in the Blackwater Mountain settlement earlier, I am willing to give you a discount on the price for some Lyson marrow extract. For 400 gold, I am willing to sell you some of it for my old friend Hjaldar.",
+        "message":"Since you helped us up here in the Blackwater mountain settlement earlier, I am willing to give you a discount on the price for some Lyson marrow extract. For 400 gold, I am willing to sell you some of it for my old friend Hjaldar.",
         "replies":[
             {
                 "text":"Here is 400 gold.",

--- a/AndorsTrail/res/raw/conversationlist_prim_guthbered.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_guthbered.json
@@ -119,10 +119,10 @@
     },
     {
         "id":"guthbered_reject",
-        "message":"You again? Leave this place and go to your friends up in the Blackwater Mountain settlement instead. We want no business with you.",
+        "message":"You again? Leave this place and go to your friends up in the Blackwater mountain settlement instead. We want no business with you.",
         "replies":[
             {
-                "text":"I am here to give you a message from the Blackwater Mountain settlement.",
+                "text":"I am here to give you a message from the Blackwater mountain settlement.",
                 "nextPhraseID":"guthbered_attacks",
                 "requires":[
                     {
@@ -139,7 +139,7 @@
         "message":"What message?",
         "replies":[
             {
-                "text":"Harlenn in the Blackwater Mountain settlement wants you to stop your attacks on their settlement.",
+                "text":"Harlenn in the Blackwater mountain settlement wants you to stop your attacks on their settlement.",
                 "nextPhraseID":"guthbered_attacks_1"
             }
         ]
@@ -157,7 +157,7 @@
     },
     {
         "id":"guthbered_return_1_1",
-        "message":"Welcome back, traveller. Did you talk to Harlenn up in the Blackwater Mountain settlement?",
+        "message":"Welcome back, traveller. Did you talk to Harlenn up in the Blackwater mountain settlement?",
         "replies":[
             {
                 "text":"Can you tell me the story about the monsters again?",
@@ -183,7 +183,7 @@
                 ]
             },
             {
-                "text":"Actually, I am here to give you a message from the Blackwater Mountain settlement.",
+                "text":"Actually, I am here to give you a message from the Blackwater mountain settlement.",
                 "nextPhraseID":"guthbered_attacks",
                 "requires":[
                     {
@@ -219,7 +219,7 @@
                 ]
             },
             {
-                "text":"Actually, I am here to give you a message from the Blackwater Mountain settlement.",
+                "text":"Actually, I am here to give you a message from the Blackwater mountain settlement.",
                 "nextPhraseID":"guthbered_attacks",
                 "requires":[
                     {
@@ -455,7 +455,7 @@
     },
     {
         "id":"guthbered_19",
-        "message":"Those evil bastards up in the Blackwater Mountain settlement probably summoned them to attack us. They would rather see us perish.",
+        "message":"Those evil bastards up in the Blackwater mountain settlement probably summoned them to attack us. They would rather see us perish.",
         "replies":[
             {
                 "text":"N",
@@ -499,7 +499,7 @@
         "message":"We used to trade with them up there, but that all changed once they got greedy.",
         "replies":[
             {
-                "text":"I met a man outside the collapsed mine saying he was from the Blackwater Mountain settlement.",
+                "text":"I met a man outside the collapsed mine saying he was from the Blackwater mountain settlement.",
                 "nextPhraseID":"guthbered_26"
             },
             {
@@ -559,7 +559,7 @@
     },
     {
         "id":"guthbered_26",
-        "message":"A man, from the Blackwater settlement, you say?",
+        "message":"A man, from the Blackwater mountain settlement, you say?",
         "replies":[
             {
                 "text":"N",
@@ -589,7 +589,7 @@
     },
     {
         "id":"guthbered_29",
-        "message":"As I said, we believe those bastards up at the Blackwater Mountain settlement are behind the monster attacks somehow.",
+        "message":"As I said, we believe those bastards up at the Blackwater mountain settlement are behind the monster attacks somehow.",
         "replies":[
             {
                 "text":"N",
@@ -602,7 +602,7 @@
         "message":"I want you to go up there to their settlement and ask their battle master, Harlenn, why they are doing this to us.",
         "replies":[
             {
-                "text":"OK, I will go ask Harlenn in the Blackwater Mountain settlement why they are attacking your village.",
+                "text":"OK, I will go ask Harlenn in the Blackwater mountain settlement why they are attacking your village.",
                 "nextPhraseID":"guthbered_31"
             }
         ],
@@ -691,7 +691,7 @@
                 "nextPhraseID":"guthbered_talkedto_harl_8"
             },
             {
-                "text":"Hmm, maybe I should help the people up in Blackwater Mountain instead.",
+                "text":"Hmm, maybe I should help the people up in Blackwater mountain instead.",
                 "nextPhraseID":"guthbered_workingforbwm_1"
             },
             {
@@ -716,7 +716,7 @@
                 "nextPhraseID":"guthbered_talkedto_harl_8"
             },
             {
-                "text":"Why would I ever want to work for your filthy village? The people in the Blackwater Mountain settlement deserve my help more than you.",
+                "text":"Why would I ever want to work for your filthy village? The people in the Blackwater mountain settlement deserve my help more than you.",
                 "nextPhraseID":"guthbered_workingforbwm_1"
             }
         ]
@@ -795,7 +795,7 @@
     },
     {
         "id":"guthbered_lookforsigns_1",
-        "message":"Hello again. Did you find anything up in the Blackwater Mountain settlement?",
+        "message":"Hello again. Did you find anything up in the Blackwater mountain settlement?",
         "replies":[
             {
                 "text":"No, I am still looking.",
@@ -926,7 +926,7 @@
     },
     {
         "id":"guthbered_workingforbwm_2",
-        "message":"My sources from inside the Blackwater Mountain settlement tell me you are working for them.",
+        "message":"My sources from inside the Blackwater mountain settlement tell me you are working for them.",
         "replies":[
             {
                 "text":"N",
@@ -947,7 +947,7 @@
     },
     {
         "id":"guthbered_completed",
-        "message":"Hello again my friend. Thank you for your help in dealing with the bandits up in Blackwater Mountain.",
+        "message":"Hello again my friend. Thank you for your help in dealing with the bandits up in Blackwater mountain.",
         "replies":[
             {
                 "text":"N",
@@ -988,11 +988,11 @@
         "message":"The glow in your eyes frightens me.",
         "replies":[
             {
-                "text":"I am sent by the Blackwater Mountain settlement to stop you.",
+                "text":"I am sent by the Blackwater mountain settlement to stop you.",
                 "nextPhraseID":"guthbered_sentbybwm_fight"
             },
             {
-                "text":"I am sent by the Blackwater Mountain settlement to stop you. However, I have decided not to kill you.",
+                "text":"I am sent by the Blackwater mountain settlement to stop you. However, I have decided not to kill you.",
                 "nextPhraseID":"guthbered_sentbybwm_3"
             }
         ]
@@ -1100,7 +1100,7 @@
     },
     {
         "id":"guthbered_killharl_1",
-        "message":"Hello again. Did you manage to remove that bastard battle master Harlenn from the Blackwater Mountain settlement?",
+        "message":"Hello again. Did you manage to remove that bastard battle master Harlenn from the Blackwater mountain settlement?",
         "replies":[
             {
                 "text":"Can you tell me again what I was supposed to do?",
@@ -1204,7 +1204,7 @@
     },
     {
         "id":"guthbered_killharl_7",
-        "message":"This is a permit that we have ... produced, which according to our sources, will allow you to enter their inner chamber in the Blackwater Mountain settlement.",
+        "message":"This is a permit that we have ... produced, which according to our sources, will allow you to enter their inner chamber in the Blackwater mountain settlement.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_prim_merchants.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_merchants.json
@@ -49,7 +49,7 @@
     },
     {
         "id":"prim_notrust",
-        "message":"Regardless, I cannot help you. My services are only for residents of Prim, and I don't trust you enough yet. You might be a spy from the Blackwater Mountain settlement."
+        "message":"Regardless, I cannot help you. My services are only for residents of Prim, and I don't trust you enough yet. You might be a spy from the Blackwater mountain settlement."
     },
     {
         "id":"prim_tailor",

--- a/AndorsTrail/res/raw/conversationlist_stoutford_combined.json
+++ b/AndorsTrail/res/raw/conversationlist_stoutford_combined.json
@@ -2935,7 +2935,7 @@
     },
     {
         "id":"cadoran_4b",
-        "message":"Follow the path to the west. There are two settlements there, Prim and Blackwater Mountain Settlement. There has been a rockfall though, making it very difficult to get to them.",
+        "message":"Follow the path to the west. There are two settlements there, Prim and Blackwater mountain Settlement. There has been a rockfall though, making it very difficult to get to them.",
         "replies":[
             {
                 "text":"Thanks for the information. What was it you said about the monsters?",
@@ -4013,7 +4013,7 @@
     },
     {
         "id":"yolgen_surroundings_0",
-        "message":"Well, to the east, there's Flagstone prison. To the south, there's Mt. Galmore. That's definitely a place that you don't want to go to. To the northwest, we have our railway terminal, and going west beyond that, you come to our border post at the Blackwater river. Nothing but bogs and marshes westwards of that. And finally, to the north, we had a tunnel leading to Prim and the Elm mine, in the heart of Blackwater Mountain.",
+        "message":"Well, to the east, there's Flagstone prison. To the south, there's Mt. Galmore. That's definitely a place that you don't want to go to. To the northwest, we have our railway terminal, and going west beyond that, you come to our border post at the Blackwater river. Nothing but bogs and marshes westwards of that. And finally, to the north, we had a tunnel leading to Prim and the Elm mine, in the heart of Blackwater mountain.",
         "replies":[
             {
                 "text":"Can you tell me more about Flagstone?",
@@ -4028,7 +4028,7 @@
                 "nextPhraseID":"yolgen_surroundings_3"
             },
             {
-                "text":"Can you tell me more about Blackwater Mountain?",
+                "text":"Can you tell me more about Blackwater mountain?",
                 "nextPhraseID":"yolgen_surroundings_4"
             },
             {
@@ -5356,7 +5356,7 @@
     },
     {
         "id":"yolgen_surroundings_4",
-        "message":"Ah. Blackwater Mountain. I will try to keep a long story short. We used to trade food and tools with Prim and the miners from Elm mine, and get loads of iron ingots in return. We shipped them on to Nor City and Feygard and prospered from the trade.",
+        "message":"Ah. Blackwater mountain. I will try to keep a long story short. We used to trade food and tools with Prim and the miners from Elm mine, and get loads of iron ingots in return. We shipped them on to Nor City and Feygard and prospered from the trade.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_v0612graves.json
+++ b/AndorsTrail/res/raw/conversationlist_v0612graves.json
@@ -141,7 +141,7 @@
     },
     {
         "id":"sign_bwm52_grave3",
-        "message":"(The cross reads: Here lies Torkurt, loyal servant of the Blackwater settlement.)"
+        "message":"(The cross reads: Here lies Torkurt, loyal servant of the Blackwater mountain settlement.)"
     },
     {
         "id":"sign_bwm52_grave4",

--- a/AndorsTrail/res/raw/questlist_v069.json
+++ b/AndorsTrail/res/raw/questlist_v069.json
@@ -6,11 +6,11 @@
         "stages":[
             {
                 "progress":1,
-                "logText":"I met a man seeking help for his settlement, the 'Blackwater Mountain'. Supposedly, his settlement is being attacked by monsters and bandits, and they need help from the outside."
+                "logText":"I met a man seeking help for his settlement, the 'Blackwater mountain'. Supposedly, his settlement is being attacked by monsters and bandits, and they need help from the outside."
             },
             {
                 "progress":5,
-                "logText":"I have agreed to help the man and Blackwater Mountain in dealing with the problem."
+                "logText":"I have agreed to help the man and Blackwater mountain in dealing with the problem."
             },
             {
                 "progress":10,
@@ -22,19 +22,19 @@
             },
             {
                 "progress":25,
-                "logText":"I heard a story about Prim and the Blackwater Mountain settlement fighting against each other."
+                "logText":"I heard a story about Prim and the Blackwater mountain settlement fighting against each other."
             },
             {
                 "progress":30,
-                "logText":"I should follow the mountain path up the mountain to the Blackwater settlement."
+                "logText":"I should follow the mountain path up the mountain to the Blackwater mountain settlement."
             },
             {
                 "progress":40,
-                "logText":"I met the man again on my way up to Blackwater Mountain. I should proceed further up the mountain."
+                "logText":"I met the man again on my way up to Blackwater mountain. I should proceed further up the mountain."
             },
             {
                 "progress":50,
-                "logText":"I have made it up to the snow-filled parts of the Blackwater Mountain. The man told me to proceed further up the mountain. Apparently, the Blackwater Mountain settlement is close by."
+                "logText":"I have made it up to the snow-filled parts of the Blackwater mountain. The man told me to proceed further up the mountain. Apparently, the Blackwater mountain settlement is close by."
             },
             {
                 "progress":60,
@@ -42,7 +42,7 @@
             },
             {
                 "progress":65,
-                "logText":"I have spoken to Harlenn in the Blackwater Mountain settlement. Apparently, the settlement is under attack by a number of monsters, the Aulaeth and white wyrms. On top of that, they are being attacked by the people of Prim."
+                "logText":"I have spoken to Harlenn in the Blackwater mountain settlement. Apparently, the settlement is under attack by a number of monsters, the Aulaeth and white wyrms. On top of that, they are being attacked by the people of Prim."
             },
             {
                 "progress":66,
@@ -50,7 +50,7 @@
             },
             {
                 "progress":70,
-                "logText":"Harlenn wants me to give a message to Guthbered of Prim. Either the people of Prim stop their attacks on the Blackwater Mountain settlement, or they will have to be dealt with themselves. I should go talk to Guthbered in Prim."
+                "logText":"Harlenn wants me to give a message to Guthbered of Prim. Either the people of Prim stop their attacks on the Blackwater mountain settlement, or they will have to be dealt with themselves. I should go talk to Guthbered in Prim."
             },
             {
                 "progress":80,
@@ -66,7 +66,7 @@
             },
             {
                 "progress":100,
-                "logText":"I have found some plans in Prim about recruiting mercenaries and attacking the Blackwater Mountain settlement. I should go talk to Harlenn immediately."
+                "logText":"I have found some plans in Prim about recruiting mercenaries and attacking the Blackwater mountain settlement. I should go talk to Harlenn immediately."
             },
             {
                 "progress":110,
@@ -75,7 +75,7 @@
             },
             {
                 "progress":120,
-                "logText":"To make the attacks on the Blackwater Mountain settlement stop, Harlenn wants me to assassinate Guthbered in Prim."
+                "logText":"To make the attacks on the Blackwater mountain settlement stop, Harlenn wants me to assassinate Guthbered in Prim."
             },
             {
                 "progress":130,
@@ -92,17 +92,17 @@
             },
             {
                 "progress":150,
-                "logText":"Harlenn thanked me for the help I have provided. Hopefully, the attacks on the Blackwater Mountain settlement should stop now.",
+                "logText":"Harlenn thanked me for the help I have provided. Hopefully, the attacks on the Blackwater mountain settlement should stop now.",
                 "rewardExperience":5000
             },
             {
                 "progress":240,
-                "logText":"I am now trusted in the Blackwater Mountain settlement, and all services should be available for me to use.",
+                "logText":"I am now trusted in the Blackwater mountain settlement, and all services should be available for me to use.",
                 "finishesQuest":1
             },
             {
                 "progress":250,
-                "logText":"I have decided to not help the people of the Blackwater Mountain settlement.",
+                "logText":"I have decided to not help the people of the Blackwater mountain settlement.",
                 "finishesQuest":1
             },
             {
@@ -119,7 +119,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"I talked to the cook in Prim, at the base of Blackwater Mountain. There is a back room available for rent, but it is currently rented out to Arghest. I should go talk to Arghest to see whether he still wants to rent the room. The cook pointed me towards the southwest of Prim."
+                "logText":"I talked to the cook in Prim, at the base of Blackwater mountain. There is a back room available for rent, but it is currently rented out to Arghest. I should go talk to Arghest to see whether he still wants to rent the room. The cook pointed me towards the southwest of Prim."
             },
             {
                 "progress":20,
@@ -148,7 +148,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"Just outside the collapsed mine on the way to Blackwater Mountain, I met a man from the village of Prim. He begged me to help them."
+                "logText":"Just outside the collapsed mine on the way to Blackwater mountain, I met a man from the village of Prim. He begged me to help them."
             },
             {
                 "progress":11,
@@ -160,23 +160,23 @@
             },
             {
                 "progress":20,
-                "logText":"I talked to Guthbered about the story about Prim. Prim has recently been under constant attack from the Blackwater Mountain settlement."
+                "logText":"I talked to Guthbered about the story about Prim. Prim has recently been under constant attack from the Blackwater mountain settlement."
             },
             {
                 "progress":25,
-                "logText":"Guthbered wants me to go up to the settlement atop the Blackwater Mountain and ask their battle master Harlenn why (or if) they have summoned the Gornaud monsters against Prim."
+                "logText":"Guthbered wants me to go up to the settlement atop the Blackwater mountain and ask their battle master Harlenn why (or if) they have summoned the Gornaud monsters against Prim."
             },
             {
                 "progress":30,
-                "logText":"I have talked to Harlenn about the attacks on Prim. He denies that the people of the Blackwater Mountain settlement have anything to do with them. I should go talk to Guthbered in Prim again."
+                "logText":"I have talked to Harlenn about the attacks on Prim. He denies that the people of the Blackwater mountain settlement have anything to do with them. I should go talk to Guthbered in Prim again."
             },
             {
                 "progress":40,
-                "logText":"Guthbered still believes that the people in the Blackwater settlement have something to do with the attacks."
+                "logText":"Guthbered still believes that the people in the Blackwater mountain settlement have something to do with the attacks."
             },
             {
                 "progress":50,
-                "logText":"Guthbered wants me to go look for any clues that the people of the Blackwater Mountain settlement is preparing for a larger attack on Prim. I should go look for hints near Harlenn's private quarters, but make sure not to be seen."
+                "logText":"Guthbered wants me to go look for any clues that the people of the Blackwater mountain settlement is preparing for a larger attack on Prim. I should go look for hints near Harlenn's private quarters, but make sure not to be seen."
             },
             {
                 "progress":60,
@@ -189,7 +189,7 @@
             },
             {
                 "progress":80,
-                "logText":"In order to make the attacks on Prim stop, Guthbered wants me to kill Harlenn up in the Blackwater Mountain settlement."
+                "logText":"In order to make the attacks on Prim stop, Guthbered wants me to kill Harlenn up in the Blackwater mountain settlement."
             },
             {
                 "progress":90,
@@ -206,7 +206,7 @@
             },
             {
                 "progress":100,
-                "logText":"Guthbered thanked me for the help I have provided to Prim. Hopefully, the attacks on Prim should stop now. As thanks, Guthbered gave me some items and a forged permit so that I can enter the inner chamber up in the Blackwater Mountain settlement.",
+                "logText":"Guthbered thanked me for the help I have provided to Prim. Hopefully, the attacks on Prim should stop now. As thanks, Guthbered gave me some items and a forged permit so that I can enter the inner chamber up in the Blackwater mountain settlement.",
                 "rewardExperience":5000
             },
             {
@@ -225,7 +225,7 @@
             },
             {
                 "progress":251,
-                "logText":"Since I am helping the Blackwater Mountain settlement, Guthbered no longer wants to talk to me.",
+                "logText":"Since I am helping the Blackwater mountain settlement, Guthbered no longer wants to talk to me.",
                 "finishesQuest":1
             }
         ]
@@ -237,7 +237,7 @@
         "stages":[
             {
                 "progress":8,
-                "logText":"I have made my way into the inner chamber in the Blackwater Mountain settlement and found a group of mages led by a man named Throdna."
+                "logText":"I have made my way into the inner chamber in the Blackwater mountain settlement and found a group of mages led by a man named Throdna."
             },
             {
                 "progress":9,
@@ -245,7 +245,7 @@
             },
             {
                 "progress":10,
-                "logText":"I have agreed to help Throdna find out more about the ritual itself, by looking for pieces of the ritual that apparently are scattered across the mountain. I should go look for the parts of the Kazaul ritual on the mountain path down from Blackwater Mountain to Prim."
+                "logText":"I have agreed to help Throdna find out more about the ritual itself, by looking for pieces of the ritual that apparently are scattered across the mountain. I should go look for the parts of the Kazaul ritual on the mountain path down from Blackwater mountain to Prim."
             },
             {
                 "progress":11,
@@ -278,7 +278,7 @@
             },
             {
                 "progress":40,
-                "logText":"Throdna wants me to put an end to the Kazaul spawn uprising that has taken place near the Blackwater Mountain. There is a shrine at the base of the mountain that i should investigate closer."
+                "logText":"Throdna wants me to put an end to the Kazaul spawn uprising that has taken place near the Blackwater mountain. There is a shrine at the base of the mountain that i should investigate closer."
             },
             {
                 "progress":41,
@@ -286,7 +286,7 @@
             },
             {
                 "progress":50,
-                "logText":"In the shrine at the base of Blackwater Mountain, I met a guardian of Kazaul. By reciting the verses of the ritual chant, I was able to make the guardian attack me."
+                "logText":"In the shrine at the base of Blackwater mountain, I met a guardian of Kazaul. By reciting the verses of the ritual chant, I was able to make the guardian attack me."
             },
             {
                 "progress":60,
@@ -307,7 +307,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"Herec on the second level of the Blackwater Mountain settlement is researching the white wyrms outside the settlement. He wants me to bring him 5 white wyrm claws so that he can continue his research. Apparently, only some of the wyrms have these claws. I will have to kill some to find them."
+                "logText":"Herec on the second level of the Blackwater mountain settlement is researching the white wyrms outside the settlement. He wants me to bring him 5 white wyrm claws so that he can continue his research. Apparently, only some of the wyrms have these claws. I will have to kill some to find them."
             },
             {
                 "progress":20,
@@ -328,7 +328,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"Bjorgur in Prim at the base of the Blackwater Mountain thinks that something has disturbed the grave of his parents, to the southwest of Prim, just outside the Elm mine."
+                "logText":"Bjorgur in Prim at the base of the Blackwater mountain thinks that something has disturbed the grave of his parents, to the southwest of Prim, just outside the Elm mine."
             },
             {
                 "progress":15,


### PR DESCRIPTION
Hello @Zukero 
As discussed in https://github.com/Zukero/andors-trail/issues/82, the correct name is _Blackwater mountain settlement_.