### PR TITLE
Fixed wording of monster names in sentences

### DIFF
--- a/AndorsTrail/res/raw/actorconditions_trader_teksin.json
+++ b/AndorsTrail/res/raw/actorconditions_trader_teksin.json
@@ -2,7 +2,7 @@
     {
         "id":"poison_irdegh_weak",
         "iconID":"actorconditions_japozero:2",
-        "name":"Weak Irdegh poison",
+        "name":"Weak irdegh poison",
         "category":"blood",
         "isStacking":1,
         "fullRoundEffect":{

--- a/AndorsTrail/res/raw/conversationlist_blackwater_harlenn.json
+++ b/AndorsTrail/res/raw/conversationlist_blackwater_harlenn.json
@@ -213,7 +213,7 @@
     },
     {
         "id":"harlenn_9",
-        "message":"Those damn beasts outside our very settlement. The white wyrms and the Aulaeth, and their trainers are even deadlier.",
+        "message":"Those damn beasts outside our very settlement. The white wyrms and the aulaeth, and their trainers are even deadlier.",
         "replies":[
             {
                 "text":"Those? They were no match for me.",
@@ -224,7 +224,7 @@
                 "nextPhraseID":"harlenn_10"
             },
             {
-                "text":"At least they aren't anything like those Gornaud beasts at the bottom of the mountain.",
+                "text":"At least they aren't anything like those gornaud beasts at the bottom of the mountain.",
                 "nextPhraseID":"harlenn_12"
             }
         ]
@@ -295,7 +295,7 @@
                 "nextPhraseID":"harlenn_16"
             },
             {
-                "text":"I talked to Guthbered in Prim. They say you are the ones doing the attacks, and that you are behind the Gornaud attacks on Prim.",
+                "text":"I talked to Guthbered in Prim. They say you are the ones doing the attacks, and that you are behind the gornaud attacks on Prim.",
                 "nextPhraseID":"harlenn_prim_1",
                 "requires":[
                     {
@@ -326,7 +326,7 @@
         "message":"We are almost certain they are the ones behind these monsters also.",
         "replies":[
             {
-                "text":"I talked to Guthbered in Prim. They say you are the ones doing the attacks, and that you are behind the Gornaud attacks on Prim.",
+                "text":"I talked to Guthbered in Prim. They say you are the ones doing the attacks, and that you are behind the gornaud attacks on Prim.",
                 "nextPhraseID":"harlenn_prim_1",
                 "requires":[
                     {
@@ -554,7 +554,7 @@
         "message":"Welcome back, traveller. What's on your mind?",
         "replies":[
             {
-                "text":"I talked to Guthbered in Prim. They say you are attacking Prim, and that you are behind the Gornaud attacks on Prim.",
+                "text":"I talked to Guthbered in Prim. They say you are attacking Prim, and that you are behind the gornaud attacks on Prim.",
                 "nextPhraseID":"harlenn_prim_1",
                 "requires":[
                     {
@@ -594,7 +594,7 @@
                 ]
             },
             {
-                "text":"I talked to Guthbered in Prim. They say you are the ones doing the attacks, and that you are behind the Gornaud attacks on Prim.",
+                "text":"I talked to Guthbered in Prim. They say you are the ones doing the attacks, and that you are behind the gornaud attacks on Prim.",
                 "nextPhraseID":"harlenn_prim_1",
                 "requires":[
                     {

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_2.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_2.json
@@ -37,7 +37,7 @@
     },
     {
         "id":"bwm_agent_2_2",
-        "message":"The Gornauds? I have no idea where they come from, one day they just showed up here around the mountain.",
+        "message":"The gornauds? I have no idea where they come from, one day they just showed up here around the mountain.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_bwm_agent_4.json
+++ b/AndorsTrail/res/raw/conversationlist_bwm_agent_4.json
@@ -19,7 +19,7 @@
     },
     {
         "id":"bwm_agent_4_1",
-        "message":"Hello again. Well done defeating the Gornaud beasts.",
+        "message":"Hello again. Well done defeating the gornaud beasts.",
         "replies":[
             {
                 "text":"Their attacks really hurt. What are these things?",

--- a/AndorsTrail/res/raw/conversationlist_crossroads_1.json
+++ b/AndorsTrail/res/raw/conversationlist_crossroads_1.json
@@ -11,7 +11,7 @@
     },
     {
         "id":"fanamor_1",
-        "message":"I was just strolling through these woods ... eh ... killing Anklebiters.",
+        "message":"I was just strolling through these woods ... eh ... killing anklebiters.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_debug.json
+++ b/AndorsTrail/res/raw/conversationlist_debug.json
@@ -373,7 +373,7 @@
 	},
     {
         "id":"chaotic_rewarder_0",
-        "message":"What do you want ?",
+        "message":"What do you want?",
         "replies":[
             {
                 "text":"Apply condition",

--- a/AndorsTrail/res/raw/conversationlist_foamingflask.json
+++ b/AndorsTrail/res/raw/conversationlist_foamingflask.json
@@ -19,7 +19,7 @@
     },
     {
         "id":"ff_cook_2",
-        "message":"Oh this? This is supposed to be a stew of Anklebiter. Needs more seasoning I guess.",
+        "message":"Oh this? This is supposed to be a stew of anklebiter. Needs more seasoning I guess.",
         "replies":[
             {
                 "text":"I look forward to trying it when it is done. Good luck cooking.",

--- a/AndorsTrail/res/raw/conversationlist_guynmart_npc.json
+++ b/AndorsTrail/res/raw/conversationlist_guynmart_npc.json
@@ -4558,7 +4558,7 @@
     },
     {
         "id":"guynmart_drunkard5_180",
-        "message":"The ground was soaked with red blood. But - it came from the Gornauds! The child just wiped the weapon clean of blood, gave us a quick glance, and disappeared up the path.",
+        "message":"The ground was soaked with red blood. But - it came from the gornauds! The child just wiped the weapon clean of blood, gave us a quick glance, and disappeared up the path.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_halvor_surprise.json
+++ b/AndorsTrail/res/raw/conversationlist_halvor_surprise.json
@@ -1549,7 +1549,7 @@
     },
     {
         "id":"halvor_chwood_6",
-        "message":"Now, I just need one last thing. I heard about some nasty snakes, called the venomscales.",
+        "message":"Now, I just need one last thing. I heard about some nasty snakes, called the venomscale.",
         "replies":[
             {
                 "text":"Snakes? I hate snakes...",
@@ -1603,7 +1603,7 @@
     },
     {
         "id":"halvor_chwood_9",
-        "message":"Have you found the venomscales scales?",
+        "message":"Have you found the venomscale scales?",
         "replies":[
             {
                 "text":"Not yet.",

--- a/AndorsTrail/res/raw/conversationlist_lodar.json
+++ b/AndorsTrail/res/raw/conversationlist_lodar.json
@@ -1089,7 +1089,7 @@
     },
     {
         "id":"lodar_spo2_0",
-        "message":"I have discovered that if you mix some ground up claws from a beast called the White Wyrm, together with a slight sprinkle of the center of a ruby gem, it can have a most interesting effect on you. Two of those claws and one gem would do.",
+        "message":"I have discovered that if you mix some ground up claws from a beast called the white wyrm, together with a slight sprinkle of the center of a ruby gem, it can have a most interesting effect on you. Two of those claws and one gem would do.",
         "replies":[
             {
                 "text":"I'll go find some of that. Let's talk about the other potions.",
@@ -1232,7 +1232,7 @@
     },
     {
         "id":"lodar_spo3_0",
-        "message":"Up in the north, I have heard tales of beast called the Arulir. Their skin is thick as bark due to the interesting oily substance that they produce. I have learned that if you extract some of that thick oily substance, and mix it with an infectious claw from some monster, you can make a potion that makes your skin almost as tough as theirs. I will require two of those skins for it to be effective, and I believe you can find the type of claws that I require on monsters that dwell underground and in caves somewhere outside Fallhaven.",
+        "message":"Up in the north, I have heard tales of beast called the arulir. Their skin is thick as bark due to the interesting oily substance that they produce. I have learned that if you extract some of that thick oily substance, and mix it with an infectious claw from some monster, you can make a potion that makes your skin almost as tough as theirs. I will require two of those skins for it to be effective, and I believe you can find the type of claws that I require on monsters that dwell underground and in caves somewhere outside Fallhaven.",
         "replies":[
             {
                 "text":"I'll go find some of that. Let's talk about the other potions.",

--- a/AndorsTrail/res/raw/conversationlist_lodarmobs.json
+++ b/AndorsTrail/res/raw/conversationlist_lodarmobs.json
@@ -1,7 +1,7 @@
 [
     {
         "id":"zortakb",
-        "message":"The Zortak will defeat you!",
+        "message":"The zortak will defeat you!",
         "replies":[
             {
                 "text":"Fight!",

--- a/AndorsTrail/res/raw/conversationlist_prim_guthbered.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_guthbered.json
@@ -435,7 +435,7 @@
     },
     {
         "id":"guthbered_17",
-        "message":"According to lore, the monsters are called the 'Gornauds'.",
+        "message":"According to lore, the monsters are called the 'gornauds'.",
         "replies":[
             {
                 "text":"Any ideas where they might be coming from?",

--- a/AndorsTrail/res/raw/conversationlist_prim_inn.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_inn.json
@@ -105,7 +105,7 @@
     },
     {
         "id":"laecca_9",
-        "message":"Pfft, 'What beasts?'. The Gornaud beasts of course.",
+        "message":"Pfft, 'What beasts?'. The gornaud beasts of course.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_prim_outside.json
+++ b/AndorsTrail/res/raw/conversationlist_prim_outside.json
@@ -172,7 +172,7 @@
     },
     {
         "id":"moyra_2",
-        "message":"Claws, beasts, Gornauds. They cannot reach me here.",
+        "message":"Claws, beasts, gornauds. They cannot reach me here.",
         "replies":[
             {
                 "text":"'Gornauds', is that what those monsters outside the village are called?",

--- a/AndorsTrail/res/raw/conversationlist_pwcave.json
+++ b/AndorsTrail/res/raw/conversationlist_pwcave.json
@@ -66,7 +66,7 @@
                 "nextPhraseID":"gauward_1"
             },
             {
-                "text":"I have some Izthiel claws to sell you.",
+                "text":"I have some izthiel claws to sell you.",
                 "nextPhraseID":"gauward_sell_1",
                 "requires":[
                     {
@@ -198,7 +198,7 @@
                 ]
             },
             {
-                "text":"Never mind. I will be back with more Izthiel claws to sell you.",
+                "text":"Never mind. I will be back with more izthiel claws to sell you.",
                 "nextPhraseID":"gauward_7"
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_remgard_villagers1.json
+++ b/AndorsTrail/res/raw/conversationlist_remgard_villagers1.json
@@ -419,7 +419,7 @@
         "message":"Oh, hello. I can't talk right now, must finish planting these crops.",
         "replies":[
             {
-                "text":"Do you know where I can find some Damerilias ?",
+                "text":"Do you know where I can find some damerilias?",
                 "nextPhraseID":"remgard_farmer1_root10_0",
                 "requires":[
                     {
@@ -442,7 +442,7 @@
         "message":"I hope the lands will be good to us this season.",
         "replies":[
             {
-                "text":"Do you know where I can find some Damerilias ?",
+                "text":"Do you know where I can find some damerilias?",
                 "nextPhraseID":"remgard_farmer2_roots10_0",
                 "requires":[
                     {

--- a/AndorsTrail/res/raw/conversationlist_stoutford.json
+++ b/AndorsTrail/res/raw/conversationlist_stoutford.json
@@ -1679,7 +1679,7 @@
     },
     {
         "id":"kayla_halvor_5",
-        "message":"I'm really proud of the result. \nThey are light, but sturdy, thanks to the bones and insect wings. \nThey are comfortable but tough thanks to the animal hair and venomscale scales. \nThey are stiff when adjusted, thanks to the rat tails.",
+        "message":"I'm really proud of the result.\nThey are light, but sturdy, thanks to the bones and insect wings.\nThey are comfortable but tough thanks to the animal hair and venomscale scales.\nThey are stiff when adjusted, thanks to the rat tails.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_stoutford_combined.json
+++ b/AndorsTrail/res/raw/conversationlist_stoutford_combined.json
@@ -175,7 +175,7 @@
     },
     {
         "id":"stoutford_widow_6",
-        "message":"I've never been there, as he always said how dangerous that road was, but every year, for our anniversary, he went back to bring me a Damerilia, the same flower he offered me on the day we met.",
+        "message":"I've never been there, as he always said how dangerous that road was, but every year, for our anniversary, he went back to bring me a damerilia, the same flower he offered me on the day we met.",
         "replies":[
             {
                 "text":"How romantic!",
@@ -195,7 +195,7 @@
     },
     {
         "id":"stoutford_widow_8",
-        "message":"I'd really love to place Damerilias on his grave, as a symbol of our love.",
+        "message":"I'd really love to place damerilias on his grave, as a symbol of our love.",
         "replies":[
             {
                 "text":"What a nice idea!",
@@ -460,10 +460,10 @@
     },
     {
         "id":"stoutford_widow_roots10_0",
-        "message":"You're back! Have you found some Damerilias yet?",
+        "message":"You're back! Have you found some damerilias yet?",
         "replies":[
             {
-                "text":"Yes. Here they are, three of the most beautiful Damerilias.",
+                "text":"Yes. Here they are, three of the most beautiful damerilias.",
                 "nextPhraseID":"stoutford_widow_roots10_2",
                 "requires":[
                     {
@@ -474,7 +474,7 @@
                 ]
             },
             {
-                "text":"Yes. Here they are, two of the most beautiful Damerilias.",
+                "text":"Yes. Here they are, two of the most beautiful damerilias.",
                 "nextPhraseID":"stoutford_widow_roots10_1a",
                 "requires":[
                     {
@@ -527,7 +527,7 @@
     },
     {
         "id":"stoutford_widow_roots10_1a",
-        "message":"Oh. But that is not enough - what would that look like! There must be at least 3 Damerilias for the grave. Please...",
+        "message":"Oh. But that is not enough - what would that look like! There must be at least 3 damerilias for the grave. Please...",
         "replies":[
             {
                 "text":"Alright. I'll go there again.",
@@ -544,7 +544,7 @@
         "message":"So much work to do. I sure hope we will have some rain soon.",
         "replies":[
             {
-                "text":"Do you know where I can find some Damerilias?",
+                "text":"Do you know where I can find some damerilias?",
                 "nextPhraseID":"caeda_root10_0"
             }
         ]
@@ -554,7 +554,7 @@
         "message":"Oh, it is you again.",
         "replies":[
             {
-                "text":"Thank you for the Damerilias.",
+                "text":"Thank you for the damerilias.",
                 "nextPhraseID":"caeda_root10_5"
             }
         ]
@@ -601,10 +601,10 @@
     },
     {
         "id":"caeda_root10_3a",
-        "message":"Every year he came to pick the most beautiful Damerilia to give it to her as a present.",
+        "message":"Every year he came to pick the most beautiful damerilia to give it to her as a present.",
         "replies":[
             {
-                "text":"Yes, Aryfora told me. She asked me to bring her some Damerilias for Noraed's grave.",
+                "text":"Yes, Aryfora told me. She asked me to bring her some damerilias for Noraed's grave.",
                 "nextPhraseID":"caeda_root10_4"
             }
         ]
@@ -637,7 +637,7 @@
     },
     {
         "id":"caeda_root10_5",
-        "message":"These Damerilias are not really good any more. You should get fresh ones from my family's glade north of Remgard.",
+        "message":"These damerilias are not really good any more. You should get fresh ones from my family's glade north of Remgard.",
         "replies":[
             {
                 "text":"How would I get to your glade?",
@@ -660,7 +660,7 @@
         "message":"The glade itself is barred by a solid door to keep the trolls out. I had a key for it of course.",
         "replies":[
             {
-                "text":"Had ?",
+                "text":"Had?",
                 "nextPhraseID":"caeda_root10_7"
             }
         ]
@@ -680,11 +680,11 @@
         "message":"Suddenly there were trolls everywhere. I barely escaped, but I must have lost the key to our glade there. If only I could have my key back!",
         "replies":[
             {
-                "text":"Your Damerilias do look a bit wilted. I will go to your glade.",
+                "text":"Your damerilias do look a bit wilted. I will go to your glade.",
                 "nextPhraseID":"caeda_root10_9"
             },
             {
-                "text":"Eh, OK. This isn't worth the trouble. Fresh Damerilias wouldn't look different after my travel back. Thank you, I will return to Stoutford directly.",
+                "text":"Eh, OK. This isn't worth the trouble. Fresh damerilias wouldn't look different after my travel back. Thank you, I will return to Stoutford directly.",
                 "nextPhraseID":"caeda_root10_8a"
             }
         ],
@@ -760,7 +760,7 @@
                 "nextPhraseID":"lakecave2_troll_20"
             },
             {
-                "text":"I am looking for some flowers called Damerilias.",
+                "text":"I am looking for some flowers called damerilias.",
                 "nextPhraseID":"lakecave2_troll_30",
                 "requires":[
                     {
@@ -805,17 +805,17 @@
     },
     {
         "id":"lakecave2_troll_30",
-        "message":"Everyone is after my Damerilias! For what? Such ugly, stinking things!\nNo, I won't give you a single one. And you really should leave now, before I get hungry!",
+        "message":"Everyone is after my damerilias! For what? Such ugly, stinking things!\nNo, I won't give you a single one. And you really should leave now, before I get hungry!",
         "replies":[
             {
-                "text":"What do you need Damerilias for, if you don't like them?",
+                "text":"What do you need damerilias for, if you don't like them?",
                 "nextPhraseID":"lakecave2_troll_32"
             }
         ]
     },
     {
         "id":"lakecave2_troll_32",
-        "message":"The Damerilias attract food for me; tasty, delicate, little people. Catching them is kind of a sport for me. It makes eating more fun.",
+        "message":"The damerilias attract food for me; tasty, delicate, little people. Catching them is kind of a sport for me. It makes eating more fun.",
         "replies":[
             {
                 "text":"N",
@@ -835,7 +835,7 @@
     },
     {
         "id":"lakecave2_troll_40",
-        "message":"What do you know about the key? I keep the key safe. Are you associated with that thief who comes once a year and steals my Damerilias?",
+        "message":"What do you know about the key? I keep the key safe. Are you associated with that thief who comes once a year and steals my damerilias?",
         "replies":[
             {
                 "text":"Do you mean Noraed? He is dead.",
@@ -858,7 +858,7 @@
         "message":"I was so looking forward to eating him.",
         "replies":[
             {
-                "text":"I would like to take some Damerilias for his grave.",
+                "text":"I would like to take some damerilias for his grave.",
                 "nextPhraseID":"lakecave2_troll_60"
             }
         ]
@@ -1245,7 +1245,7 @@
     },
     {
         "id":"caeda_root60_1",
-        "message":"Yes, of course. I will give you my father's key. Keep it. Then you can always pick Damerilias for Noraed's grave.",
+        "message":"Yes, of course. I will give you my father's key. Keep it. Then you can always pick damerilias for Noraed's grave.",
         "replies":[
             {
                 "text":"That would be great, thank you.",
@@ -1292,14 +1292,14 @@
     },
     {
         "id":"remgard_farmer2_roots10_0",
-        "message":"Damerilias. I haven't seen one in a long time. Try with Caeda, she used to give us a Damerilia sometimes.",
+        "message":"Damerilias. I haven't seen one in a long time. Try with Caeda, she used to give us a damerilia sometimes.",
         "replies":[
             {
                 "text":"Thank you.",
                 "nextPhraseID":"X"
             },
             {
-                "text":"Caeda ?",
+                "text":"Caeda?",
                 "nextPhraseID":"remgard_farmer2_roots10_1"
             }
         ]
@@ -1382,7 +1382,7 @@
     },
     {
         "id":"stoutford_widow_roots30_0",
-        "message":"How did you find these flowers ?",
+        "message":"How did you find these flowers?",
         "replies":[
             {
                 "text":"Caeda, Noraed's sister, gave them to me. She sends you her condolences.",
@@ -2132,7 +2132,7 @@
     },
     {
         "id":"stoutford_widow2_3",
-        "message":"I won't sell this potion for money. You can pay me in flowers - damerilias of course. \nI will give you one potion of deftness for three damerilias.",
+        "message":"I won't sell this potion for money. You can pay me in flowers - damerilias of course.\nI will give you one potion of deftness for three damerilias.",
         "replies":[
             {
                 "text":"OK, I have some damerilias with me.",

--- a/AndorsTrail/res/raw/conversationlist_talion_2.json
+++ b/AndorsTrail/res/raw/conversationlist_talion_2.json
@@ -204,7 +204,7 @@
     },
     {
         "id":"talion_infect_15",
-        "message":"Third, I will need a gland of poison from a creature called the Irdegh.",
+        "message":"Third, I will need a gland of poison from a creature called the irdegh.",
         "replies":[
             {
                 "text":"N",
@@ -214,10 +214,10 @@
     },
     {
         "id":"talion_infect_16",
-        "message":"Now, I have not seen an Irdegh myself, but I hear they are particularly nasty creatures. Venomous like nothing I've heard of.",
+        "message":"Now, I have not seen an irdegh myself, but I hear they are particularly nasty creatures. Venomous like nothing I've heard of.",
         "replies":[
             {
-                "text":"OK, one Irdegh poison gland. Where can I find one?",
+                "text":"OK, one irdegh poison gland. Where can I find one?",
                 "nextPhraseID":"talion_infect_17"
             },
             {
@@ -280,7 +280,7 @@
                 "nextPhraseID":"talion_hair_s"
             },
             {
-                "text":"I brought an Irdegh poison gland for you.",
+                "text":"I brought an irdegh poison gland for you.",
                 "nextPhraseID":"talion_irdegh_s"
             },
             {
@@ -321,7 +321,7 @@
                 "nextPhraseID":"talion_hair_s"
             },
             {
-                "text":"I brought an Irdegh poison gland for you.",
+                "text":"I brought an irdegh poison gland for you.",
                 "nextPhraseID":"talion_irdegh_s"
             },
             {

--- a/AndorsTrail/res/raw/conversationlist_thorin.json
+++ b/AndorsTrail/res/raw/conversationlist_thorin.json
@@ -71,7 +71,7 @@
     },
     {
         "id":"thorin_story_1",
-        "message":"You see, me and my fellow gatherers were out investigating the poisonous nature of the Irdegh.",
+        "message":"You see, me and my fellow gatherers were out investigating the poisonous nature of the irdegh.",
         "replies":[
             {
                 "text":"N",
@@ -101,7 +101,7 @@
     },
     {
         "id":"thorin_story_4",
-        "message":"Those 'Scaradon' things are tough! They did not even seem to take any damage when I hit them.",
+        "message":"Those 'scaradon' things are tough! They did not even seem to take any damage when I hit them.",
         "replies":[
             {
                 "text":"N",
@@ -173,7 +173,7 @@
     },
     {
         "id":"thorin_story_9",
-        "message":"Considering how they died, I would be very interested in seeing what effects both the Irdegh and the Scaradons had on them.",
+        "message":"Considering how they died, I would be very interested in seeing what effects both the irdegh and the scaradons had on them.",
         "replies":[
             {
                 "text":"N",
@@ -309,7 +309,7 @@
     },
     {
         "id":"thorin_trade_y",
-        "message":"Oh yes. The upside of this cave is that it literally is crawling with dead bodies of those Scaradon bugs.",
+        "message":"Oh yes. The upside of this cave is that it literally is crawling with dead bodies of those scaradon bugs.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/conversationlist_ulirfendor.json
+++ b/AndorsTrail/res/raw/conversationlist_ulirfendor.json
@@ -235,7 +235,7 @@
     },
     {
         "id":"ulirfendor_8",
-        "message":"Ah, the Allaceph. I had not seen one for many years until I entered this cave. They are a remnant of the guardians of Kazaul.",
+        "message":"Ah, the allaceph. I had not seen one for many years until I entered this cave. They are a remnant of the guardians of Kazaul.",
         "replies":[
             {
                 "text":"N",

--- a/AndorsTrail/res/raw/monsterlist_v070_lodarmaze.json
+++ b/AndorsTrail/res/raw/monsterlist_v070_lodarmaze.json
@@ -677,7 +677,7 @@
     },
     {
         "id":"vscale1",
-        "name":"Puny venomscales",
+        "name":"Puny venomscale",
         "iconID":"monsters_tometik4:21",
         "maxHP":42,
         "moveCost":5,
@@ -707,7 +707,7 @@
     },
     {
         "id":"vscale2",
-        "name":"Young venomscales",
+        "name":"Young venomscale",
         "iconID":"monsters_tometik4:21",
         "maxHP":46,
         "moveCost":5,
@@ -737,7 +737,7 @@
     },
     {
         "id":"vscale3",
-        "name":"Gray venomscales",
+        "name":"Gray venomscale",
         "iconID":"monsters_tometik4:17",
         "maxHP":48,
         "moveCost":5,
@@ -767,7 +767,7 @@
     },
     {
         "id":"vscale4",
-        "name":"Aggressive venomscales",
+        "name":"Aggressive venomscale",
         "iconID":"monsters_tometik4:17",
         "maxHP":52,
         "moveCost":5,
@@ -797,7 +797,7 @@
     },
     {
         "id":"vscale5",
-        "name":"Quick venomscales",
+        "name":"Quick venomscale",
         "iconID":"monsters_tometik4:22",
         "maxHP":56,
         "moveCost":5,
@@ -827,7 +827,7 @@
     },
     {
         "id":"vscale6",
-        "name":"Vicious venomscales",
+        "name":"Vicious venomscale",
         "iconID":"monsters_tometik4:22",
         "maxHP":59,
         "moveCost":5,
@@ -857,7 +857,7 @@
     },
     {
         "id":"vscale7",
-        "name":"Strong venomscales",
+        "name":"Strong venomscale",
         "iconID":"monsters_tometik4:32",
         "maxHP":63,
         "moveCost":5,
@@ -887,7 +887,7 @@
     },
     {
         "id":"vscale8",
-        "name":"Tough venomscales",
+        "name":"Tough venomscale",
         "iconID":"monsters_tometik4:32",
         "maxHP":67,
         "moveCost":5,
@@ -917,7 +917,7 @@
     },
     {
         "id":"vscaleb1",
-        "name":"Breeder of venomscales",
+        "name":"Breeder of venomscale",
         "iconID":"monsters_tometik7:56",
         "maxHP":197,
         "moveCost":5,

--- a/AndorsTrail/res/raw/questlist_halvor_surprise.json
+++ b/AndorsTrail/res/raw/questlist_halvor_surprise.json
@@ -125,7 +125,7 @@
             },
             {
                 "progress":170,
-                "logText":"Now, Halvor wants me to find 10 scales from venomscales snakes."
+                "logText":"Now, Halvor wants me to find 10 scales from venomscale snakes."
             },
             {
                 "progress":175,

--- a/AndorsTrail/res/raw/questlist_nondisplayed.json
+++ b/AndorsTrail/res/raw/questlist_nondisplayed.json
@@ -30,7 +30,7 @@
             },
             {
                 "progress":20,
-                "logText":"Selling Izthiel claws to Gauward"
+                "logText":"Selling izthiel claws to Gauward"
             },
             {
                 "progress":21,
@@ -58,43 +58,43 @@
             },
             {
                 "progress":30,
-                "logText":"Damerialia #1 fetched in lakecave1"
+                "logText":"Damerilia #1 fetched in lakecave1"
             },
             {
                 "progress":31,
-                "logText":"Damerialia #1 grew back in lakecave1"
+                "logText":"Damerilia #1 grew back in lakecave1"
             },
             {
                 "progress":32,
-                "logText":"Damerialia #2 fetched in lakecave1"
+                "logText":"Damerilia #2 fetched in lakecave1"
             },
             {
                 "progress":33,
-                "logText":"Damerialia #2 grew back in lakecave1"
+                "logText":"Damerilia #2 grew back in lakecave1"
             },
             {
                 "progress":34,
-                "logText":"Damerialia #3 fetched in lakecave1"
+                "logText":"Damerilia #3 fetched in lakecave1"
             },
             {
                 "progress":35,
-                "logText":"Damerialia #3 grew back in lakecave1"
+                "logText":"Damerilia #3 grew back in lakecave1"
             },
             {
                 "progress":36,
-                "logText":"Damerialia #4 fetched in lakecave1"
+                "logText":"Damerilia #4 fetched in lakecave1"
             },
             {
                 "progress":37,
-                "logText":"Damerialia #4 grew back in lakecave1"
+                "logText":"Damerilia #4 grew back in lakecave1"
             },
             {
                 "progress":38,
-                "logText":"Damerialia #5 fetched in lakecave1"
+                "logText":"Damerilia #5 fetched in lakecave1"
             },
             {
                 "progress":39,
-                "logText":"Damerialia #5 grew back in lakecave1"
+                "logText":"Damerilia #5 grew back in lakecave1"
             }
         ]
     },

--- a/AndorsTrail/res/raw/questlist_stoutford_combined.json
+++ b/AndorsTrail/res/raw/questlist_stoutford_combined.json
@@ -6,15 +6,15 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"Aryfora, a woman grieving in Stoutford's graveyard asked me to bring her some Damerilias from Remgard for the grave of Noraed, her husband."
+                "logText":"Aryfora, a woman grieving in Stoutford's graveyard asked me to bring her some damerilias from Remgard for the grave of Noraed, her husband."
             },
             {
                 "progress":20,
-                "logText":"Noraed's sister, Caeda, gave me some Damerilias. I should bring them back to Stoutford."
+                "logText":"Noraed's sister, Caeda, gave me some damerilias. I should bring them back to Stoutford."
             },
             {
                 "progress":30,
-                "logText":"I have brought the Damerilias back to Aryfora. She thanked me with a potion she made.",
+                "logText":"I have brought the damerilias back to Aryfora. She thanked me with a potion she made.",
                 "rewardExperience":3500
             },
             {
@@ -36,11 +36,11 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"Caeda in Remgard told me I can find fresh Damerilias in her family's glade, but the key was taken by monsters. \nIf I can find the key in the cave north of Remgard, I can access that glade, but I have to return the key to Caeda."
+                "logText":"Caeda in Remgard told me I can find fresh damerilias in her family's glade, but the key was taken by monsters.\nIf I can find the key in the cave north of Remgard, I can access that glade, but I have to return the key to Caeda."
             },
             {
                 "progress":20,
-                "logText":"Finding the key was not worth the trouble. The wilted Damerilias Caeda gave me will be just fine.",
+                "logText":"Finding the key was not worth the trouble. The wilted damerilias Caeda gave me will be just fine.",
                 "finishesQuest":1
             },
             {

--- a/AndorsTrail/res/raw/questlist_v0611_2.json
+++ b/AndorsTrail/res/raw/questlist_v0611_2.json
@@ -150,7 +150,7 @@
             },
             {
                 "progress":30,
-                "logText":"Talion in Loneford told me that in order to be cured of my affliction, I will need to bring four parts to him. The parts that I will need are five bones, two pieces of animal hair, one Irdegh poison gland and one empty vial. Bones and fur can probably be found on some animal in the wilderness, and the poison gland can be found on one of the Irdeghs that have been spotted to the east."
+                "logText":"Talion in Loneford told me that in order to be cured of my affliction, I will need to bring four parts to him. The parts that I will need are five bones, two pieces of animal hair, one irdegh poison gland and one empty vial. Bones and fur can probably be found on some animal in the wilderness, and the poison gland can be found on one of the irdeghs that have been spotted to the east."
             },
             {
                 "progress":40,
@@ -162,7 +162,7 @@
             },
             {
                 "progress":42,
-                "logText":"I have brought one Irdegh poison gland to Talion."
+                "logText":"I have brought one irdegh poison gland to Talion."
             },
             {
                 "progress":43,

--- a/AndorsTrail/res/raw/questlist_v069.json
+++ b/AndorsTrail/res/raw/questlist_v069.json
@@ -42,7 +42,7 @@
             },
             {
                 "progress":65,
-                "logText":"I have spoken to Harlenn in the Blackwater mountain settlement. Apparently, the settlement is under attack by a number of monsters, the Aulaeth and white wyrms. On top of that, they are being attacked by the people of Prim."
+                "logText":"I have spoken to Harlenn in the Blackwater mountain settlement. Apparently, the settlement is under attack by a number of monsters, the aulaeth and white wyrms. On top of that, they are being attacked by the people of Prim."
             },
             {
                 "progress":66,
@@ -164,7 +164,7 @@
             },
             {
                 "progress":25,
-                "logText":"Guthbered wants me to go up to the settlement atop the Blackwater mountain and ask their battle master Harlenn why (or if) they have summoned the Gornaud monsters against Prim."
+                "logText":"Guthbered wants me to go up to the settlement atop the Blackwater mountain and ask their battle master Harlenn why (or if) they have summoned the gornaud monsters against Prim."
             },
             {
                 "progress":30,

--- a/AndorsTrail/res/raw/questlist_v070_lodar.json
+++ b/AndorsTrail/res/raw/questlist_v070_lodar.json
@@ -77,7 +77,7 @@
             },
             {
                 "progress":43,
-                "logText":"Lodar can create a potent defensive potion if I bring him two Arulir skins and a claw from some monster. The Arulir beasts can be found somewhere up in the north, and the claws can apparently be found from creatures that dwell underground and in caves somewhere outside Fallhaven."
+                "logText":"Lodar can create a potent defensive potion if I bring him two arulir skins and a claw from some monster. The arulir beasts can be found somewhere up in the north, and the claws can apparently be found from creatures that dwell underground and in caves somewhere outside Fallhaven."
             }
         ]
     },


### PR DESCRIPTION
Hello @Zukero 
This pull request fixes all the wording issues, that we talked about in https://github.com/Zukero/andors-trail/issues/79.
_Venomscales_ are now changed to _venomscale_ globally.