### PR TITLE
Fix a typo in the Stoutford gate guard's stories

### DIFF
--- a/AndorsTrail/res/raw/conversationlist_stoutford.json
+++ b/AndorsTrail/res/raw/conversationlist_stoutford.json
@@ -114,7 +114,7 @@
     },
     {
         "id":"soutford_gateguard_what_0",
-        "message":"This is Stoutford. Our small town was the resting place of choice for many merchants on their way between Fallhaven and the Blackwater moutain.",
+        "message":"This is Stoutford. Our small town was the resting place of choice for many merchants on their way between Fallhaven and the Blackwater mountain.",
         "replies":[
             {
                 "text":"Was?",


### PR DESCRIPTION
I noticed this while playing the game; a search of the rest of the source 
code confirms that it's a typo.