### PR TITLE
Fix taunt combat log bug

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/AndorsTrailApplication.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/AndorsTrailApplication.java
@@ -23,7 +23,7 @@ public final class AndorsTrailApplication extends Application {
 	public static final boolean DEVELOPMENT_DEBUGRESOURCES = false;
 	public static final boolean DEVELOPMENT_FORCE_STARTNEWGAME = false;
 	public static final boolean DEVELOPMENT_FORCE_CONTINUEGAME = false;
-	public static final boolean DEVELOPMENT_DEBUGBUTTONS = true;
+	public static final boolean DEVELOPMENT_DEBUGBUTTONS = false;
 	public static final boolean DEVELOPMENT_FASTSPEED = false;
 	public static final boolean DEVELOPMENT_VALIDATEDATA = false;
 	public static final boolean DEVELOPMENT_DEBUGMESSAGES = false;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/AndorsTrailApplication.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/AndorsTrailApplication.java
@@ -23,7 +23,7 @@ public final class AndorsTrailApplication extends Application {
 	public static final boolean DEVELOPMENT_DEBUGRESOURCES = false;
 	public static final boolean DEVELOPMENT_FORCE_STARTNEWGAME = false;
 	public static final boolean DEVELOPMENT_FORCE_CONTINUEGAME = false;
-	public static final boolean DEVELOPMENT_DEBUGBUTTONS = false;
+	public static final boolean DEVELOPMENT_DEBUGBUTTONS = true;
 	public static final boolean DEVELOPMENT_FASTSPEED = false;
 	public static final boolean DEVELOPMENT_VALIDATEDATA = false;
 	public static final boolean DEVELOPMENT_DEBUGMESSAGES = false;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -406,6 +406,7 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		} else {
 			combatActionListeners.onMonsterAttackMissed(currentActiveMonster, attack);
 			startMissedEffect(attack, world.model.player.position, this, CALLBACK_MONSTERATTACK);
+			controllers.skillController.applySkillEffectsFromMonsterAttack(attack, currentActiveMonster);
 		}
 	}
 
@@ -513,13 +514,11 @@ public final class CombatController implements VisualEffectCompletedCallback {
 
 	private AttackResult playerAttacks(Monster currentMonster) {
 		AttackResult result = attack(world.model.player, currentMonster);
-		controllers.skillController.applySkillEffectsFromPlayerAttack(result, currentMonster);
 		return result;
 	}
 
 	private AttackResult monsterAttacks(Monster currentMonster) {
 		AttackResult result = attack(currentMonster, world.model.player);
-		controllers.skillController.applySkillEffectsFromMonsterAttack(result, currentMonster);
 		return result;
 	}
 

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -514,6 +514,7 @@ public final class CombatController implements VisualEffectCompletedCallback {
 
 	private AttackResult playerAttacks(Monster currentMonster) {
 		AttackResult result = attack(world.model.player, currentMonster);
+		controllers.skillController.applySkillEffectsFromPlayerAttack(result, currentMonster);
 		return result;
 	}
 


### PR DESCRIPTION
Removed the call to apply taunt skill effect from the playerAttacks method and moved it to the attackWithCurrentMonster() method after the engine has determined that the monster has missed
which is after the missed event is logged.