### PR TITLE
Improved localization handling on screen turn (might fix issue #125)

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/AndorsTrailApplication.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/AndorsTrailApplication.java
@@ -60,13 +60,12 @@ public final class AndorsTrailApplication extends Application {
 		} else {
 			activity.getWindow().setFlags(0, WindowManager.LayoutParams.FLAG_FULLSCREEN);
 		}
-		setLocale(activity);
 	}
 
 	//Get default locale at startup, as somehow it seems that changing the app's 
 	//configured locale impacts the value returned by Locale.getDefault() nowadays.
 	private final Locale defaultLocale = Locale.getDefault();
-	
+
 	@SuppressLint("NewApi")
 	public boolean setLocale(Activity context) {
 		Resources res = context.getResources();

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AboutActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AboutActivity.java
@@ -16,7 +16,7 @@ import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
 import com.gpl.rpg.AndorsTrail.R;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 
-public final class AboutActivity extends Activity implements ImageGetter {
+public final class AboutActivity extends AndorsTrailBaseActivity implements ImageGetter {
 
 	/** Called when the activity is first created. */
 	@Override

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ActorConditionInfoActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ActorConditionInfoActivity.java
@@ -18,7 +18,7 @@ import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 import com.gpl.rpg.AndorsTrail.view.AbilityModifierInfoView;
 import com.gpl.rpg.AndorsTrail.view.ItemEffectsView_OnUse;
 
-public final class ActorConditionInfoActivity extends Activity {
+public final class ActorConditionInfoActivity extends AndorsTrailBaseActivity {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AndorsTrailBaseActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AndorsTrailBaseActivity.java
@@ -10,9 +10,6 @@ public abstract class AndorsTrailBaseActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         AndorsTrailApplication app = AndorsTrailApplication.getApplicationFromActivity(this);
-        if (!app.isInitialized()) {
-            return;
-        }
         app.setLocale(this);
     }
 

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AndorsTrailBaseActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AndorsTrailBaseActivity.java
@@ -1,0 +1,26 @@
+package com.gpl.rpg.AndorsTrail.activity;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
+
+public abstract class AndorsTrailBaseActivity extends Activity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        AndorsTrailApplication app = AndorsTrailApplication.getApplicationFromActivity(this);
+        if (!app.isInitialized()) {
+            return;
+        }
+        app.setLocale(this);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        AndorsTrailApplication app = AndorsTrailApplication.getApplicationFromActivity(this);
+        app.setLocale(this);
+    }
+}
+

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AndorsTrailBaseFragmentActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AndorsTrailBaseFragmentActivity.java
@@ -1,0 +1,28 @@
+package com.gpl.rpg.AndorsTrail.activity;
+
+import android.app.Activity;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+
+import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
+import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
+
+public abstract class AndorsTrailBaseFragmentActivity extends FragmentActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        AndorsTrailApplication app = AndorsTrailApplication.getApplicationFromActivity(this);
+        if (!app.isInitialized()) {
+            return;
+        }
+        app.setLocale(this);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        AndorsTrailApplication app = AndorsTrailApplication.getApplicationFromActivity(this);
+        app.setLocale(this);
+    }
+}

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AndorsTrailBaseFragmentActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/AndorsTrailBaseFragmentActivity.java
@@ -13,9 +13,6 @@ public abstract class AndorsTrailBaseFragmentActivity extends FragmentActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         AndorsTrailApplication app = AndorsTrailApplication.getApplicationFromActivity(this);
-        if (!app.isInitialized()) {
-            return;
-        }
         app.setLocale(this);
     }
 

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/BulkSelectionInterface.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/BulkSelectionInterface.java
@@ -29,7 +29,7 @@ import com.gpl.rpg.AndorsTrail.view.CustomDialogFactory;
  * @author ejwessel
  * Creates the BulkSelectionInterface dialog that allows for buy/drop/selling
  */
-public final class BulkSelectionInterface extends Activity implements TextWatcher {
+public final class BulkSelectionInterface extends AndorsTrailBaseActivity implements TextWatcher {
 
 	// class variables
 	public static enum BulkInterfaceType {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ConversationActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ConversationActivity.java
@@ -46,7 +46,7 @@ import com.gpl.rpg.AndorsTrail.resource.tiles.TileManager;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 
 public final class ConversationActivity
-		extends Activity
+		extends AndorsTrailBaseActivity
 		implements OnKeyListener
 		, ConversationController.ConversationStatemachine.ConversationStateListener {
 

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/DisplayWorldMapActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/DisplayWorldMapActivity.java
@@ -24,7 +24,7 @@ import android.webkit.WebViewClient;
 import android.widget.Button;
 import android.widget.Toast;
 
-public final class DisplayWorldMapActivity extends Activity {
+public final class DisplayWorldMapActivity extends AndorsTrailBaseActivity {
 	private WorldContext world;
 
 	private WebView displayworldmap_webview;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/HeroinfoActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/HeroinfoActivity.java
@@ -1,5 +1,6 @@
 package com.gpl.rpg.AndorsTrail.activity;
 
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
@@ -18,7 +19,7 @@ import com.gpl.rpg.AndorsTrail.activity.fragment.HeroinfoActivity_Stats;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 
-public final class HeroinfoActivity extends FragmentActivity {
+public final class HeroinfoActivity extends AndorsTrailBaseFragmentActivity {
 	private WorldContext world;
 
 	private FragmentTabHost tabHost;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ItemInfoActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ItemInfoActivity.java
@@ -18,7 +18,7 @@ import com.gpl.rpg.AndorsTrail.model.item.ItemType;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 import com.gpl.rpg.AndorsTrail.view.ItemEffectsView;
 
-public final class ItemInfoActivity extends Activity {
+public final class ItemInfoActivity extends AndorsTrailBaseActivity {
 
 	public static enum ItemInfoAction {
 		none, use, equip, unequip, buy, sell

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/LevelUpActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/LevelUpActivity.java
@@ -18,7 +18,7 @@ import com.gpl.rpg.AndorsTrail.controller.Constants;
 import com.gpl.rpg.AndorsTrail.model.actor.Player;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 
-public final class LevelUpActivity extends Activity {
+public final class LevelUpActivity extends AndorsTrailBaseActivity {
 	private WorldContext world;
 	private ControllerContext controllers;
 	private Player player;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/LoadSaveActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/LoadSaveActivity.java
@@ -29,7 +29,7 @@ import com.gpl.rpg.AndorsTrail.savegames.Savegames.FileHeader;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 import com.gpl.rpg.AndorsTrail.view.CustomDialogFactory;
 
-public final class LoadSaveActivity extends Activity implements OnClickListener {
+public final class LoadSaveActivity extends AndorsTrailBaseActivity implements OnClickListener {
 	private boolean isLoading = true;
 	private static final int SLOT_NUMBER_CREATE_NEW_SLOT = -1;
 	private static final int SLOT_NUMBER_FIRST_SLOT = 1;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/LoadingActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/LoadingActivity.java
@@ -22,7 +22,7 @@ import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 import com.gpl.rpg.AndorsTrail.view.CloudsAnimatorView;
 import com.gpl.rpg.AndorsTrail.view.CustomDialogFactory;
 
-public final class LoadingActivity extends Activity implements OnResourcesLoadedListener, OnSceneLoadedListener {
+public final class LoadingActivity extends AndorsTrailBaseActivity implements OnResourcesLoadedListener, OnSceneLoadedListener {
 
 	private WorldSetup setup;
 	private Dialog progressDialog;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
@@ -54,7 +54,7 @@ import com.gpl.rpg.AndorsTrail.view.ToolboxView;
 import com.gpl.rpg.AndorsTrail.view.VirtualDpadView;
 
 public final class MainActivity
-		extends Activity
+		extends AndorsTrailBaseActivity
 		implements
 		PlayerMovementListener
 		, CombatActionListener

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/MonsterEncounterActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/MonsterEncounterActivity.java
@@ -16,7 +16,7 @@ import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.model.actor.Monster;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 
-public final class MonsterEncounterActivity extends Activity {
+public final class MonsterEncounterActivity extends AndorsTrailBaseActivity {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/MonsterInfoActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/MonsterInfoActivity.java
@@ -20,7 +20,7 @@ import com.gpl.rpg.AndorsTrail.view.ItemEffectsView;
 import com.gpl.rpg.AndorsTrail.view.RangeBar;
 import com.gpl.rpg.AndorsTrail.view.TraitsInfoView;
 
-public final class MonsterInfoActivity extends Activity {
+public final class MonsterInfoActivity extends AndorsTrailBaseActivity {
 
 	private WorldContext world;
 	private ControllerContext controllers;

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/Preferences.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/Preferences.java
@@ -15,11 +15,22 @@ public final class Preferences extends PreferenceActivity {
 		setTheme(ThemeHelper.getBaseTheme());
 		requestWindowFeature(Window.FEATURE_NO_TITLE);
 		super.onCreate(savedInstanceState);
-		if (AndorsTrailApplication.getApplicationFromActivity(this).getPreferences().fullscreen) {
+		AndorsTrailApplication app = AndorsTrailApplication.getApplicationFromActivity(this);
+		if (app.getPreferences().fullscreen) {
 			getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
 		} else {
 			getWindow().setFlags(0, WindowManager.LayoutParams.FLAG_FULLSCREEN);
 		}
+
+		app.setLocale(this);
 		addPreferencesFromResource(R.xml.preferences);
 	}
+
+	@Override
+	protected void onResume() {
+		super.onResume();
+		AndorsTrailApplication app = AndorsTrailApplication.getApplicationFromActivity(this);
+		app.setLocale(this);
+	}
 }
+

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ShopActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/ShopActivity.java
@@ -16,7 +16,7 @@ import com.gpl.rpg.AndorsTrail.activity.fragment.ShopActivity_Buy;
 import com.gpl.rpg.AndorsTrail.activity.fragment.ShopActivity_Sell;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 
-public final class ShopActivity extends FragmentActivity {
+public final class ShopActivity extends AndorsTrailBaseFragmentActivity {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/SkillInfoActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/SkillInfoActivity.java
@@ -21,7 +21,7 @@ import com.gpl.rpg.AndorsTrail.model.ability.SkillInfo.SkillLevelRequirement;
 import com.gpl.rpg.AndorsTrail.model.actor.Player;
 import com.gpl.rpg.AndorsTrail.util.ThemeHelper;
 
-public final class SkillInfoActivity extends Activity {
+public final class SkillInfoActivity extends AndorsTrailBaseActivity {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/StartScreenActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/StartScreenActivity.java
@@ -29,7 +29,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-public final class StartScreenActivity extends FragmentActivity implements OnNewGameRequestedListener, GameCreationOverListener, OnBackStackChangedListener {
+public final class StartScreenActivity extends AndorsTrailBaseFragmentActivity implements OnNewGameRequestedListener, GameCreationOverListener, OnBackStackChangedListener {
 
 	private TextView tv;
 	private TextView development_version;


### PR DESCRIPTION
- in some activities the code for setting the locale was missing and therefore a simple turn of the device switched to localized texts even if localized resources were disabled
- for all other activities there was the problem that the locale was set only in onCreate but in some special cases the config is reset but only onResume gets called (e.g. when turning the device, hitting the home button, turning the device back and then switching to AT again). Setting it only in onResume would be too late for the regular cases. The code is almost a noop if there is no change to be done so it seems ok to call it twice.
- created two baseclasses for activities to encapsulate the logic and increase the chance that a new activity will be based on that classes and the code will not be forgotten
- might fix issue #125 "Localized resources showing even when disabled"
- ways of working solutions for setting the locale differ from API level to API level (see https://proandroiddev.com/change-language-programmatically-at-runtime-on-android-5e6bc15c758)
- tested on android Pie and Marshmallow